### PR TITLE
Fix reference to as-pect.d.ts

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -170,8 +170,7 @@ in your project automatically. If you use this method for your types, feel
 free to delete the auto-generated types file in your test folder.
 
 ```ts
-/// <reference path="../node_modules/@as-pect/core/types/as-pect.d.ts" />
-/// <reference path="../node_modules/@as-pect/core/types/as-pect.portable.d.ts" />
+/// <reference path="../node_modules/@as-pect/assembly/types/as-pect.d.ts" />
 ```
 
 ## CI Usage


### PR DESCRIPTION
The files were outdated in @as-pect 2.7.0.

This now uses the same path that is generated with `asp --types`