### PR TITLE
Support instantiation of module from config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "version": "file:packages/cli",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^3.0.0-alpha.3",
-        "@as-pect/core": "^3.0.0-alpha.3",
-        "@as-pect/csv-reporter": "^3.0.0-alpha.3",
-        "@as-pect/json-reporter": "^3.0.0-alpha.3",
+        "@as-pect/assembly": "^3.0.0-beta.0",
+        "@as-pect/core": "^3.0.0-beta.0",
+        "@as-pect/csv-reporter": "^3.0.0-beta.0",
+        "@as-pect/json-reporter": "^3.0.0-beta.0",
         "chalk": "^3.0.0",
         "glob": "^7.1.6"
       }
@@ -23,7 +23,7 @@
       "version": "file:packages/core",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^3.0.0-alpha.3",
+        "@as-pect/assembly": "^3.0.0-beta.0",
         "chalk": "^3.0.0",
         "long": "^4.0.0"
       }
@@ -32,14 +32,14 @@
       "version": "file:packages/csv-reporter",
       "dev": true,
       "requires": {
-        "@as-pect/core": "^3.0.0-alpha.3"
+        "@as-pect/core": "^3.0.0-beta.0"
       }
     },
     "@as-pect/json-reporter": {
       "version": "file:packages/json-reporter",
       "dev": true,
       "requires": {
-        "@as-pect/core": "^3.0.0-alpha.3"
+        "@as-pect/core": "^3.0.0-beta.0"
       }
     },
     "@babel/code-frame": {

--- a/packages/assembly/assembly/__tests__/instantiateImports.spec.imports.js
+++ b/packages/assembly/assembly/__tests__/instantiateImports.spec.imports.js
@@ -1,0 +1,7 @@
+module.exports = function (_memory, createImports, instantiateSync, binary) {
+  return instantiateSync(binary, createImports({
+    api: {
+      identity(input) { return input; },
+    }
+  }));
+};

--- a/packages/assembly/assembly/__tests__/instantiateImports.spec.ts
+++ b/packages/assembly/assembly/__tests__/instantiateImports.spec.ts
@@ -1,0 +1,9 @@
+// @ts-ignore: decorator
+@external("api", "identity")
+declare function identity(input: i32): i32;
+
+describe("a module with overridden imports", () => {
+  test("the thing", () => {
+    expect(identity(42)).toBe(42, "The instantiated function import should return 42.");
+  });
+});

--- a/packages/assembly/assembly/__tests__/instantiateImports.spec.ts
+++ b/packages/assembly/assembly/__tests__/instantiateImports.spec.ts
@@ -4,6 +4,9 @@ declare function identity(input: i32): i32;
 
 describe("a module with overridden imports", () => {
   test("the thing", () => {
-    expect(identity(42)).toBe(42, "The instantiated function import should return 42.");
+    expect(identity(42)).toBe(
+      42,
+      "The instantiated function import should return 42.",
+    );
   });
 });

--- a/packages/assembly/assembly/__tests__/instantiateImports.spec.wat
+++ b/packages/assembly/assembly/__tests__/instantiateImports.spec.wat
@@ -1,0 +1,2323 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+ (import "env" "memory" (memory $0 1))
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 176) "@\00\00\00\01\00\00\00\01\00\00\00@\00\00\00a\00 \00m\00o\00d\00u\00l\00e\00 \00w\00i\00t\00h\00 \00o\00v\00e\00r\00r\00i\00d\00d\00e\00n\00 \00i\00m\00p\00o\00r\00t\00s\00")
+ (data (i32.const 256) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00t\00h\00e\00 \00t\00h\00i\00n\00g\00")
+ (data (i32.const 304) "d\00\00\00\01\00\00\00\01\00\00\00d\00\00\00T\00h\00e\00 \00i\00n\00s\00t\00a\00n\00t\00i\00a\00t\00e\00d\00 \00f\00u\00n\00c\00t\00i\00o\00n\00 \00i\00m\00p\00o\00r\00t\00 \00s\00h\00o\00u\00l\00d\00 \00r\00e\00t\00u\00r\00n\00 \004\002\00.\00")
+ (data (i32.const 432) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00i\003\002\00")
+ (data (i32.const 464) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 512) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
+ (data (i32.const 576) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00a\00s\00s\00e\00r\00t\00.\00t\00s\00")
+ (data (i32.const 656) "\07\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\98\04\01\00\00\00\00\00\10\00\00\00\00\00\00\00\93\00\00\00\02\00\00\00")
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
+ (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
+ (import "api" "identity" (func $assembly/__tests__/instantiateImports.spec/identity (param i32) (result i32)))
+ (import "__aspect" "createReflectedValue" (func $assembly/internal/Reflect/createReflectedValue (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+ (import "__aspect" "attachStackTraceToReflectedValue" (func $assembly/internal/Reflect/attachStackTraceToReflectedValue (param i32)))
+ (import "__aspect" "reportActualReflectedValue" (func $assembly/internal/Actual/reportActualReflectedValue (param i32)))
+ (import "__aspect" "reportInvalidExpectCall" (func $assembly/internal/Expected/reportInvalidExpectCall))
+ (import "__aspect" "reportExpectedReflectedValue" (func $assembly/internal/Expected/reportExpectedReflectedValue (param i32 i32)))
+ (import "__aspect" "clearActual" (func $assembly/internal/Actual/clearActual))
+ (import "__aspect" "clearExpected" (func $assembly/internal/Expected/clearExpected))
+ (import "__aspect" "reportTest" (func $assembly/internal/Test/reportTest (param i32 i32)))
+ (import "__aspect" "reportDescribe" (func $assembly/internal/Describe/reportDescribe (param i32)))
+ (import "__aspect" "reportEndDescribe" (func $assembly/internal/Describe/reportEndDescribe))
+ (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
+ (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
+ (table $0 4 funcref)
+ (elem (i32.const 1) $start:assembly/__tests__/instantiateImports.spec~anonymous|0~anonymous|0 $start:assembly/__tests__/instantiateImports.spec~anonymous|0 $start:assembly/internal/noOp~anonymous|0)
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
+ (global $~lib/gc/gc.auto (mut i32) (i32.const 1))
+ (global $assembly/internal/Expected/Expected.ready (mut i32) (i32.const 0))
+ (global $assembly/internal/Reflect/Reflect.FAILED_MATCH i32 (i32.const 0))
+ (global $assembly/internal/Reflect/Reflect.SUCCESSFUL_MATCH i32 (i32.const 1))
+ (global $assembly/internal/Reflect/Reflect.DEFER_MATCH i32 (i32.const 2))
+ (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
+ (global $~argumentsLength (mut i32) (i32.const 0))
+ (global $assembly/internal/noOp/noOp i32 (i32.const 3))
+ (global $assembly/__tests__/setup/Test.include/meaningOfLife i32 (i32.const 42))
+ (global $assembly/internal/log/ignoreLogs (mut i32) (i32.const 0))
+ (global $assembly/internal/RTrace/RTrace.enabled (mut i32) (i32.const 1))
+ (global $~started (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 656))
+ (global $~lib/heap/__heap_base i32 (i32.const 716))
+ (export "__setArgumentsLength" (func $~setArgumentsLength))
+ (export "_start" (func $~start))
+ (export "memory" (memory $0))
+ (export "table" (table $0))
+ (export "__alloc" (func $~lib/rt/tlsf/__alloc))
+ (export "__retain" (func $~lib/rt/pure/__retain))
+ (export "__release" (func $~lib/rt/pure/__release))
+ (export "__collect" (func $~lib/rt/pure/__collect))
+ (export "__rtti_base" (global $~lib/rt/__rtti_base))
+ (export "meaningOfLife" (global $assembly/__tests__/setup/Test.include/meaningOfLife))
+ (export "__ready" (func $assembly/index/__ready))
+ (export "__call" (func $assembly/internal/call/__call))
+ (export "__ignoreLogs" (func $assembly/internal/log/__ignoreLogs))
+ (export "__disableRTrace" (func $assembly/internal/RTrace/__disableRTrace))
+ (export "__getUsizeArrayId" (func $assembly/internal/RTrace/__getUsizeArrayId))
+ (func $~lib/rt/tlsf/removeBlock (; 16 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  i32.load
+  local.set $2
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 277
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $3
+  local.get $3
+  i32.const 16
+  i32.ge_u
+  if (result i32)
+   local.get $3
+   i32.const 1073741808
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 279
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $4
+   local.get $3
+   i32.const 4
+   i32.shr_u
+   local.set $5
+  else
+   i32.const 31
+   local.get $3
+   i32.clz
+   i32.sub
+   local.set $4
+   local.get $3
+   local.get $4
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $5
+   local.get $4
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $4
+  end
+  local.get $4
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $5
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 292
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load offset=16
+  local.set $6
+  local.get $1
+  i32.load offset=20
+  local.set $7
+  local.get $6
+  if
+   local.get $6
+   local.get $7
+   i32.store offset=20
+  end
+  local.get $7
+  if
+   local.get $7
+   local.get $6
+   i32.store offset=16
+  end
+  local.get $1
+  local.get $0
+  local.set $10
+  local.get $4
+  local.set $9
+  local.get $5
+  local.set $8
+  local.get $10
+  local.get $9
+  i32.const 4
+  i32.shl
+  local.get $8
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  i32.eq
+  if
+   local.get $0
+   local.set $11
+   local.get $4
+   local.set $10
+   local.get $5
+   local.set $9
+   local.get $7
+   local.set $8
+   local.get $11
+   local.get $10
+   i32.const 4
+   i32.shl
+   local.get $9
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.store offset=96
+   local.get $7
+   i32.eqz
+   if
+    local.get $0
+    local.set $9
+    local.get $4
+    local.set $8
+    local.get $9
+    local.get $8
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.set $9
+    local.get $0
+    local.set $8
+    local.get $4
+    local.set $11
+    local.get $9
+    i32.const 1
+    local.get $5
+    i32.shl
+    i32.const -1
+    i32.xor
+    i32.and
+    local.tee $9
+    local.set $10
+    local.get $8
+    local.get $11
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $10
+    i32.store offset=4
+    local.get $9
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const 1
+     local.get $4
+     i32.shl
+     i32.const -1
+     i32.xor
+     i32.and
+     i32.store
+    end
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/insertBlock (; 17 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  local.get $1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 205
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load
+  local.set $2
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 207
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const 16
+  i32.add
+  local.get $3
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.add
+  local.set $4
+  local.get $4
+  i32.load
+  local.set $5
+  local.get $5
+  i32.const 1
+  i32.and
+  if
+   local.get $2
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $3
+   local.get $3
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $4
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $2
+    i32.const 3
+    i32.and
+    local.get $3
+    i32.or
+    local.tee $2
+    i32.store
+    local.get $1
+    local.set $6
+    local.get $6
+    i32.const 16
+    i32.add
+    local.get $6
+    i32.load
+    i32.const 3
+    i32.const -1
+    i32.xor
+    i32.and
+    i32.add
+    local.set $4
+    local.get $4
+    i32.load
+    local.set $5
+   end
+  end
+  local.get $2
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.sub
+   i32.load
+   local.set $6
+   local.get $6
+   i32.load
+   local.set $3
+   local.get $3
+   i32.const 1
+   i32.and
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 32
+    i32.const 228
+    i32.const 15
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $3
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $2
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $7
+   local.get $7
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/tlsf/removeBlock
+    local.get $6
+    local.get $3
+    i32.const 3
+    i32.and
+    local.get $7
+    i32.or
+    local.tee $2
+    i32.store
+    local.get $6
+    local.set $1
+   end
+  end
+  local.get $4
+  local.get $5
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $2
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $8
+  local.get $8
+  i32.const 16
+  i32.ge_u
+  if (result i32)
+   local.get $8
+   i32.const 1073741808
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 243
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $8
+  i32.add
+  local.get $4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 244
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $8
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $9
+   local.get $8
+   i32.const 4
+   i32.shr_u
+   local.set $10
+  else
+   i32.const 31
+   local.get $8
+   i32.clz
+   i32.sub
+   local.set $9
+   local.get $8
+   local.get $9
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $10
+   local.get $9
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $9
+  end
+  local.get $9
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $10
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 260
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $7
+  local.get $9
+  local.set $3
+  local.get $10
+  local.set $6
+  local.get $7
+  local.get $3
+  i32.const 4
+  i32.shl
+  local.get $6
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  local.set $11
+  local.get $1
+  i32.const 0
+  i32.store offset=16
+  local.get $1
+  local.get $11
+  i32.store offset=20
+  local.get $11
+  if
+   local.get $11
+   local.get $1
+   i32.store offset=16
+  end
+  local.get $0
+  local.set $12
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $1
+  local.set $6
+  local.get $12
+  local.get $7
+  i32.const 4
+  i32.shl
+  local.get $3
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $6
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $9
+  i32.shl
+  i32.or
+  i32.store
+  local.get $0
+  local.set $13
+  local.get $9
+  local.set $12
+  local.get $0
+  local.set $3
+  local.get $9
+  local.set $6
+  local.get $3
+  local.get $6
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const 1
+  local.get $10
+  i32.shl
+  i32.or
+  local.set $7
+  local.get $13
+  local.get $12
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $7
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/addMemory (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $1
+  local.get $2
+  i32.le_u
+  if (result i32)
+   local.get $1
+   i32.const 15
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  if (result i32)
+   local.get $2
+   i32.const 15
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 386
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  local.set $4
+  i32.const 0
+  local.set $5
+  local.get $4
+  if
+   local.get $1
+   local.get $4
+   i32.const 16
+   i32.add
+   i32.ge_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 32
+    i32.const 396
+    i32.const 15
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 16
+   i32.sub
+   local.get $4
+   i32.eq
+   if
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.set $1
+    local.get $4
+    i32.load
+    local.set $5
+   else
+    nop
+   end
+  else
+   local.get $1
+   local.get $0
+   i32.const 1572
+   i32.add
+   i32.ge_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 32
+    i32.const 408
+    i32.const 4
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $2
+  local.get $1
+  i32.sub
+  local.set $6
+  local.get $6
+  i32.const 48
+  i32.lt_u
+  if
+   i32.const 0
+   return
+  end
+  local.get $6
+  i32.const 16
+  i32.const 1
+  i32.shl
+  i32.sub
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  local.get $7
+  i32.const 1
+  i32.or
+  local.get $5
+  i32.const 2
+  i32.and
+  i32.or
+  i32.store
+  local.get $8
+  i32.const 0
+  i32.store offset=16
+  local.get $8
+  i32.const 0
+  i32.store offset=20
+  local.get $1
+  local.get $6
+  i32.add
+  i32.const 16
+  i32.sub
+  local.set $4
+  local.get $4
+  i32.const 0
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $0
+  local.set $9
+  local.get $4
+  local.set $3
+  local.get $9
+  local.get $3
+  i32.store offset=1568
+  local.get $0
+  local.get $8
+  call $~lib/rt/tlsf/insertBlock
+  i32.const 1
+ )
+ (func $~lib/rt/tlsf/maybeInitialize (; 19 ;) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  global.get $~lib/rt/tlsf/ROOT
+  local.set $0
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/heap/__heap_base
+   i32.const 15
+   i32.add
+   i32.const -16
+   i32.and
+   local.set $1
+   memory.size
+   local.set $2
+   local.get $1
+   i32.const 1572
+   i32.add
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $3
+   local.get $2
+   i32.gt_s
+   if (result i32)
+    local.get $3
+    local.get $2
+    i32.sub
+    memory.grow
+    i32.const 0
+    i32.lt_s
+   else
+    i32.const 0
+   end
+   if
+    unreachable
+   end
+   local.get $1
+   local.set $0
+   local.get $0
+   i32.const 0
+   i32.store
+   local.get $0
+   local.set $5
+   i32.const 0
+   local.set $4
+   local.get $5
+   local.get $4
+   i32.store offset=1568
+   i32.const 0
+   local.set $5
+   loop $for-loop|0
+    local.get $5
+    i32.const 23
+    i32.lt_u
+    local.set $4
+    local.get $4
+    if
+     local.get $0
+     local.set $8
+     local.get $5
+     local.set $7
+     i32.const 0
+     local.set $6
+     local.get $8
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $6
+     i32.store offset=4
+     i32.const 0
+     local.set $8
+     loop $for-loop|1
+      local.get $8
+      i32.const 16
+      i32.lt_u
+      local.set $7
+      local.get $7
+      if
+       local.get $0
+       local.set $11
+       local.get $5
+       local.set $10
+       local.get $8
+       local.set $9
+       i32.const 0
+       local.set $6
+       local.get $11
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $9
+       i32.add
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $6
+       i32.store offset=96
+       local.get $8
+       i32.const 1
+       i32.add
+       local.set $8
+       br $for-loop|1
+      end
+     end
+     local.get $5
+     i32.const 1
+     i32.add
+     local.set $5
+     br $for-loop|0
+    end
+   end
+   local.get $0
+   local.get $1
+   i32.const 1572
+   i32.add
+   i32.const 15
+   i32.add
+   i32.const 15
+   i32.const -1
+   i32.xor
+   i32.and
+   memory.size
+   i32.const 16
+   i32.shl
+   call $~lib/rt/tlsf/addMemory
+   drop
+   local.get $0
+   global.set $~lib/rt/tlsf/ROOT
+  end
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/prepareSize (; 20 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.ge_u
+  if
+   i32.const 80
+   i32.const 32
+   i32.const 457
+   i32.const 29
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.tee $1
+  i32.const 16
+  local.tee $2
+  local.get $1
+  local.get $2
+  i32.gt_u
+  select
+ )
+ (func $~lib/rt/tlsf/searchBlock (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $2
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $3
+  else
+   local.get $1
+   i32.const 536870904
+   i32.lt_u
+   if (result i32)
+    local.get $1
+    i32.const 1
+    i32.const 27
+    local.get $1
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+   else
+    local.get $1
+   end
+   local.set $4
+   i32.const 31
+   local.get $4
+   i32.clz
+   i32.sub
+   local.set $2
+   local.get $4
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $3
+   local.get $2
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $2
+  end
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $3
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 338
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $5
+  local.get $4
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const 0
+  i32.const -1
+  i32.xor
+  local.get $3
+  i32.shl
+  i32.and
+  local.set $6
+  i32.const 0
+  local.set $7
+  local.get $6
+  i32.eqz
+  if
+   local.get $0
+   i32.load
+   i32.const 0
+   i32.const -1
+   i32.xor
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
+   i32.and
+   local.set $5
+   local.get $5
+   i32.eqz
+   if
+    i32.const 0
+    local.set $7
+   else
+    local.get $5
+    i32.ctz
+    local.set $2
+    local.get $0
+    local.set $8
+    local.get $2
+    local.set $4
+    local.get $8
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.set $6
+    local.get $6
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 32
+     i32.const 351
+     i32.const 17
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.set $9
+    local.get $2
+    local.set $8
+    local.get $6
+    i32.ctz
+    local.set $4
+    local.get $9
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=96
+    local.set $7
+   end
+  else
+   local.get $0
+   local.set $9
+   local.get $2
+   local.set $8
+   local.get $6
+   i32.ctz
+   local.set $4
+   local.get $9
+   local.get $8
+   i32.const 4
+   i32.shl
+   local.get $4
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load offset=96
+   local.set $7
+  end
+  local.get $7
+ )
+ (func $~lib/rt/tlsf/growMemory (; 22 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
+  memory.size
+  local.set $2
+  local.get $1
+  i32.const 16
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.ne
+  i32.shl
+  i32.add
+  local.set $1
+  local.get $1
+  i32.const 65535
+  i32.add
+  i32.const 65535
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.shr_u
+  local.set $4
+  local.get $2
+  local.tee $3
+  local.get $4
+  local.tee $5
+  local.get $3
+  local.get $5
+  i32.gt_s
+  select
+  local.set $6
+  local.get $6
+  memory.grow
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    unreachable
+   end
+  end
+  memory.size
+  local.set $7
+  local.get $0
+  local.get $2
+  i32.const 16
+  i32.shl
+  local.get $7
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+  drop
+ )
+ (func $~lib/rt/tlsf/prepareBlock (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.load
+  local.set $3
+  local.get $2
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 365
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.get $2
+  i32.sub
+  local.set $4
+  local.get $4
+  i32.const 32
+  i32.ge_u
+  if
+   local.get $1
+   local.get $2
+   local.get $3
+   i32.const 2
+   i32.and
+   i32.or
+   i32.store
+   local.get $1
+   i32.const 16
+   i32.add
+   local.get $2
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $4
+   i32.const 16
+   i32.sub
+   i32.const 1
+   i32.or
+   i32.store
+   local.get $0
+   local.get $5
+   call $~lib/rt/tlsf/insertBlock
+  else
+   local.get $1
+   local.get $3
+   i32.const 1
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.store
+   local.get $1
+   local.set $5
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.get $1
+   local.set $5
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   i32.load
+   i32.const 2
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.store
+  end
+ )
+ (func $~lib/rt/tlsf/allocateBlock (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/rt/tlsf/collectLock
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 490
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  call $~lib/rt/tlsf/prepareSize
+  local.set $3
+  local.get $0
+  local.get $3
+  call $~lib/rt/tlsf/searchBlock
+  local.set $4
+  local.get $4
+  i32.eqz
+  if
+   global.get $~lib/gc/gc.auto
+   if
+    i32.const 1
+    global.set $~lib/rt/tlsf/collectLock
+    call $~lib/rt/pure/__collect
+    i32.const 0
+    global.set $~lib/rt/tlsf/collectLock
+    local.get $0
+    local.get $3
+    call $~lib/rt/tlsf/searchBlock
+    local.set $4
+    local.get $4
+    i32.eqz
+    if
+     local.get $0
+     local.get $3
+     call $~lib/rt/tlsf/growMemory
+     local.get $0
+     local.get $3
+     call $~lib/rt/tlsf/searchBlock
+     local.set $4
+     local.get $4
+     i32.eqz
+     if
+      i32.const 0
+      i32.const 32
+      i32.const 502
+      i32.const 19
+      call $~lib/builtins/abort
+      unreachable
+     end
+    end
+   else
+    local.get $0
+    local.get $3
+    call $~lib/rt/tlsf/growMemory
+    local.get $0
+    local.get $3
+    call $~lib/rt/tlsf/searchBlock
+    local.set $4
+    local.get $4
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 32
+     i32.const 507
+     i32.const 17
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+  end
+  local.get $4
+  i32.load
+  i32.const -4
+  i32.and
+  local.get $3
+  i32.ge_u
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 510
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 0
+  i32.store offset=4
+  local.get $4
+  local.get $2
+  i32.store offset=8
+  local.get $4
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $4
+  call $~lib/rt/tlsf/removeBlock
+  local.get $0
+  local.get $4
+  local.get $3
+  call $~lib/rt/tlsf/prepareBlock
+  local.get $4
+  call $~lib/rt/rtrace/onalloc
+  local.get $4
+ )
+ (func $~lib/rt/tlsf/__alloc (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+  call $~lib/rt/tlsf/maybeInitialize
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/allocateBlock
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/rt/pure/increment (; 26 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 27 ;) (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/rt/pure/__release (; 28 ;) (param $0 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
+ )
+ (func $assembly/internal/Expectation/Expectation<i32>#constructor (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 8
+   i32.const 3
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+ )
+ (func $assembly/internal/Expectation/expect<i32> (; 30 ;) (param $0 i32) (result i32)
+  i32.const 0
+  local.get $0
+  call $assembly/internal/Expectation/Expectation<i32>#constructor
+ )
+ (func $assembly/internal/Box/Box<i32>#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 4
+   i32.const 5
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+ )
+ (func $assembly/internal/Reflect/Reflect.toReflectedValue<i32> (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 0
+  local.get $0
+  call $assembly/internal/Box/Box<i32>#constructor
+  local.set $2
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  local.get $2
+  i32.const 1
+  i32.const 4
+  i32.const 7
+  i32.const 0
+  i32.const 448
+  local.get $2
+  i32.const 0
+  i32.const 0
+  call $assembly/internal/Reflect/createReflectedValue
+  local.set $3
+  local.get $3
+  local.set $4
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $4
+  return
+ )
+ (func $~lib/memory/memory.fill (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i32)
+  block $~lib/util/memory/memset|inlined.0
+   local.get $0
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $3
+   local.get $3
+   i32.eqz
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 2
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 1
+   i32.add
+   local.get $4
+   i32.store8
+   local.get $5
+   i32.const 2
+   i32.add
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 6
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 3
+   i32.add
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 8
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   i32.const 0
+   local.get $5
+   i32.sub
+   i32.const 3
+   i32.and
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.add
+   local.set $5
+   local.get $3
+   local.get $6
+   i32.sub
+   local.set $3
+   local.get $3
+   i32.const -4
+   i32.and
+   local.set $3
+   i32.const -1
+   i32.const 255
+   i32.div_u
+   local.get $4
+   i32.const 255
+   i32.and
+   i32.mul
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $3
+   i32.const 8
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $3
+   i32.const 24
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 12
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
+   i32.const 24
+   local.get $5
+   i32.const 4
+   i32.and
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.add
+   local.set $5
+   local.get $3
+   local.get $6
+   i32.sub
+   local.set $3
+   local.get $7
+   i64.extend_i32_u
+   local.get $7
+   i64.extend_i32_u
+   i64.const 32
+   i64.shl
+   i64.or
+   local.set $8
+   loop $while-continue|0
+    local.get $3
+    i32.const 32
+    i32.ge_u
+    local.set $9
+    local.get $9
+    if
+     local.get $5
+     local.get $8
+     i64.store
+     local.get $5
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
+     local.get $5
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
+     local.get $5
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
+     local.get $3
+     i32.const 32
+     i32.sub
+     local.set $3
+     local.get $5
+     i32.const 32
+     i32.add
+     local.set $5
+     br $while-continue|0
+    end
+   end
+  end
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 1073741808
+  i32.gt_u
+  if
+   i32.const 480
+   i32.const 528
+   i32.const 54
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $2
+  local.get $2
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
+  local.get $2
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/map/Map<usize,i32>#clear (; 35 ;) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<usize,i32>#constructor (; 36 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 4
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<usize,i32>#clear
+  local.get $0
+ )
+ (func $assembly/internal/Reflect/Reflect.toReflectedValue<i32>|trampoline (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  block $1of1
+   block $0of1
+    block $outOfRange
+     global.get $~argumentsLength
+     i32.const 1
+     i32.sub
+     br_table $0of1 $1of1 $outOfRange
+    end
+    unreachable
+   end
+   i32.const 0
+   call $~lib/map/Map<usize,i32>#constructor
+   local.tee $2
+   local.set $1
+  end
+  local.get $0
+  local.get $1
+  call $assembly/internal/Reflect/Reflect.toReflectedValue<i32>
+  local.set $3
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+ )
+ (func $~setArgumentsLength (; 38 ;) (param $0 i32)
+  local.get $0
+  global.set $~argumentsLength
+ )
+ (func $assembly/internal/Reflect/Reflect.attachStackTrace (; 39 ;) (param $0 i32)
+  local.get $0
+  call $assembly/internal/Reflect/attachStackTraceToReflectedValue
+ )
+ (func $assembly/internal/Actual/Actual.report<i32> (; 40 ;) (param $0 i32)
+  (local $1 i32)
+  i32.const 1
+  global.set $~argumentsLength
+  local.get $0
+  i32.const 0
+  call $assembly/internal/Reflect/Reflect.toReflectedValue<i32>|trampoline
+  local.set $1
+  local.get $1
+  call $assembly/internal/Reflect/Reflect.attachStackTrace
+  local.get $1
+  call $assembly/internal/Actual/reportActualReflectedValue
+ )
+ (func $assembly/internal/Expected/Expected.report<i32> (; 41 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  global.get $assembly/internal/Expected/Expected.ready
+  i32.eqz
+  if
+   call $assembly/internal/Expected/reportInvalidExpectCall
+   return
+  end
+  i32.const 1
+  global.set $~argumentsLength
+  local.get $0
+  i32.const 0
+  call $assembly/internal/Reflect/Reflect.toReflectedValue<i32>|trampoline
+  local.set $2
+  local.get $2
+  call $assembly/internal/Reflect/Reflect.attachStackTrace
+  local.get $2
+  local.get $1
+  call $assembly/internal/Expected/reportExpectedReflectedValue
+ )
+ (func $assembly/internal/assert/assert (; 42 ;) (param $0 i32) (param $1 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $0
+  i32.eqz
+  if
+   local.get $1
+   call $~lib/rt/pure/__release
+   local.get $1
+   i32.const 592
+   i32.const 9
+   i32.const 18
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $assembly/internal/Actual/Actual.clear (; 43 ;)
+  call $assembly/internal/Actual/clearActual
+ )
+ (func $assembly/internal/Expected/Expected.clear (; 44 ;)
+  call $assembly/internal/Expected/clearExpected
+ )
+ (func $assembly/internal/Expectation/Expectation<i32>#toBe (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.eq
+  local.set $3
+  local.get $0
+  i32.load offset=4
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $0
+  i32.load
+  call $assembly/internal/Expected/Expected.report<i32>
+  local.get $3
+  local.get $0
+  i32.load
+  i32.xor
+  local.get $2
+  call $assembly/internal/assert/assert
+  call $assembly/internal/Actual/Actual.clear
+  call $assembly/internal/Expected/Expected.clear
+  local.get $2
+  call $~lib/rt/pure/__release
+ )
+ (func $start:assembly/__tests__/instantiateImports.spec~anonymous|0~anonymous|0 (; 46 ;)
+  (local $0 i32)
+  i32.const 42
+  call $assembly/__tests__/instantiateImports.spec/identity
+  call $assembly/internal/Expectation/expect<i32>
+  local.tee $0
+  i32.const 42
+  i32.const 320
+  call $assembly/internal/Expectation/Expectation<i32>#toBe
+  local.get $0
+  call $~lib/rt/pure/__release
+ )
+ (func $assembly/internal/Test/test (; 47 ;) (param $0 i32) (param $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $0
+  local.get $1
+  call $assembly/internal/Test/reportTest
+  local.get $0
+  call $~lib/rt/pure/__release
+ )
+ (func $start:assembly/__tests__/instantiateImports.spec~anonymous|0 (; 48 ;)
+  i32.const 272
+  i32.const 1
+  call $assembly/internal/Test/test
+ )
+ (func $start:assembly/internal/noOp~anonymous|0 (; 49 ;)
+  nop
+ )
+ (func $assembly/internal/Describe/describe (; 50 ;) (param $0 i32) (param $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $0
+  call $assembly/internal/Describe/reportDescribe
+  i32.const 0
+  global.set $~argumentsLength
+  local.get $1
+  call_indirect (type $none_=>_none)
+  call $assembly/internal/Describe/reportEndDescribe
+  local.get $0
+  call $~lib/rt/pure/__release
+ )
+ (func $start:assembly/__tests__/instantiateImports.spec (; 51 ;)
+  i32.const 192
+  i32.const 2
+  call $assembly/internal/Describe/describe
+ )
+ (func $assembly/index/__ready (; 52 ;)
+  i32.const 1
+  global.set $assembly/internal/Expected/Expected.ready
+ )
+ (func $assembly/internal/call/__call (; 53 ;) (param $0 i32)
+  i32.const 0
+  global.set $~argumentsLength
+  local.get $0
+  call_indirect (type $none_=>_none)
+ )
+ (func $assembly/internal/log/__ignoreLogs (; 54 ;) (param $0 i32)
+  local.get $0
+  i32.const 0
+  i32.ne
+  global.set $assembly/internal/log/ignoreLogs
+ )
+ (func $assembly/internal/RTrace/__disableRTrace (; 55 ;)
+  i32.const 0
+  global.set $assembly/internal/RTrace/RTrace.enabled
+ )
+ (func $assembly/internal/RTrace/__getUsizeArrayId (; 56 ;) (result i32)
+  i32.const 6
+ )
+ (func $~start (; 57 ;)
+  global.get $~started
+  if
+   return
+  else
+   i32.const 1
+   global.set $~started
+  end
+  call $start:assembly/__tests__/instantiateImports.spec
+ )
+ (func $~lib/rt/pure/__collect (; 58 ;)
+  return
+ )
+ (func $~lib/rt/tlsf/freeBlock (; 59 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $1
+  i32.load
+  local.set $2
+  local.get $1
+  local.get $2
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+  local.get $1
+  call $~lib/rt/rtrace/onfree
+ )
+ (func $~lib/rt/pure/decrement (; 60 ;) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 268435455
+  i32.and
+  local.set $2
+  local.get $0
+  call $~lib/rt/rtrace/ondecrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 122
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 1
+   call $~lib/rt/__visit_members
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.eqz
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 144
+    i32.const 126
+    i32.const 17
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/rt/tlsf/ROOT
+   local.get $0
+   call $~lib/rt/tlsf/freeBlock
+  else
+   local.get $2
+   i32.const 0
+   i32.gt_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 144
+    i32.const 136
+    i32.const 15
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 268435455
+   i32.const -1
+   i32.xor
+   i32.and
+   local.get $2
+   i32.const 1
+   i32.sub
+   i32.or
+   i32.store offset=4
+  end
+ )
+ (func $~lib/rt/pure/__visit (; 61 ;) (param $0 i32) (param $1 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.lt_u
+  if
+   return
+  end
+  local.get $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 69
+   i32.const 15
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 16
+  i32.sub
+  call $~lib/rt/pure/decrement
+ )
+ (func $~lib/map/Map<usize,i32>#__visit_impl (; 62 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/array/Array<usize>#__visit_impl (; 63 ;) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/rt/__visit_members (; 64 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  block $block$4$break
+   block $switch$1$default
+    block $switch$1$case$8
+     block $switch$1$case$6
+      block $switch$1$case$4
+       block $switch$1$case$2
+        local.get $0
+        i32.const 8
+        i32.sub
+        i32.load
+        br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$2 $switch$1$case$6 $switch$1$case$2 $switch$1$case$8 $switch$1$default
+       end
+       return
+      end
+      br $block$4$break
+     end
+     local.get $0
+     local.get $1
+     call $~lib/map/Map<usize,i32>#__visit_impl
+     return
+    end
+    local.get $0
+    local.get $1
+    call $~lib/array/Array<usize>#__visit_impl
+    br $block$4$break
+   end
+   unreachable
+  end
+  local.get $0
+  i32.load
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/pure/__visit
+  end
+  return
+ )
+)

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -477,15 +477,24 @@ export function run(cliOptions: Options, compilerArgs: string[]): void {
       }
 
       const memory = new WebAssembly.Memory(memoryDescriptor);
-      const stagedImports =
-        typeof configurationImports === "function"
-          ? configurationImports(memory)
-          : configurationImports;
-      const imports = runner.createImports(stagedImports);
-      imports.env.memory = memory;
 
-      // instantiate the module
-      const wasm: IAspectExports = instantiateSync(binary, imports);
+      let wasm: IAspectExports;
+
+      if (typeof configurationImports === "function") {
+        const imports = runner.createImports();
+        imports.env.memory = memory;
+        wasm = configurationImports(memory, imports, instantiateSync, binary);
+        if (!wasm) {
+          console.error(
+            chalk`{red [Error]} Imports configuration function did not return an AssemblyScript module. (Did you forget to return it?)`,
+          );
+          process.exit(1);
+        }
+      } else {
+        const imports = runner.createImports(configurationImports);
+        imports.env.memory = memory;
+        wasm = instantiateSync(binary, imports);
+      }
 
       if (runner.errors.length > 0) {
         errors.push(...runner.errors);

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -481,9 +481,8 @@ export function run(cliOptions: Options, compilerArgs: string[]): void {
       let wasm: IAspectExports;
 
       if (typeof configurationImports === "function") {
-        const imports = runner.createImports();
-        imports.env.memory = memory;
-        wasm = configurationImports(memory, imports, instantiateSync, binary);
+        const createImports = runner.createImports.bind(runner, { env: { memory } });
+        wasm = configurationImports(memory, createImports, instantiateSync, binary);
         if (!wasm) {
           console.error(
             chalk`{red [Error]} Imports configuration function did not return an AssemblyScript module. (Did you forget to return it?)`,

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -481,8 +481,15 @@ export function run(cliOptions: Options, compilerArgs: string[]): void {
       let wasm: IAspectExports;
 
       if (typeof configurationImports === "function") {
-        const createImports = runner.createImports.bind(runner, { env: { memory } });
-        wasm = configurationImports(memory, createImports, instantiateSync, binary);
+        const createImports = runner.createImports.bind(runner, {
+          env: { memory },
+        });
+        wasm = configurationImports(
+          memory,
+          createImports,
+          instantiateSync,
+          binary,
+        );
         if (!wasm) {
           console.error(
             chalk`{red [Error]} Imports configuration function did not return an AssemblyScript module. (Did you forget to return it?)`,

--- a/packages/core/src/test/TestCollector.ts
+++ b/packages/core/src/test/TestCollector.ts
@@ -318,9 +318,7 @@ export class TestCollector {
       performanceEnabled: this.performanceEnabled.bind(this),
       pushReflectedObjectKey: this.pushReflectedObjectKey.bind(this),
       pushReflectedObjectValue: this.pushReflectedObjectValue.bind(this),
-      reportActualReflectedValue: this.reportActualReflectedValue.bind(
-        this,
-      ),
+      reportActualReflectedValue: this.reportActualReflectedValue.bind(this),
       reportAfterAll: this.reportAfterAll.bind(this),
       reportAfterEach: this.reportAfterEach.bind(this),
       reportAverage: this.reportAverage.bind(this),

--- a/packages/core/src/test/TestCollector.ts
+++ b/packages/core/src/test/TestCollector.ts
@@ -273,100 +273,106 @@ export class TestCollector {
    * @param {any[]} imports - Every import item specified.
    */
   public createImports(...imports: any[]): any {
-    const result = Object.assign(
-      {},
-      ...imports, // get all the user defined imports
-      {
-        __aspect: {
-          attachStackTraceToReflectedValue: this.attachStackTraceToReflectedValue.bind(
-            this,
-          ),
-          clearActual: this.clearActual.bind(this),
-          clearExpected: this.clearExpected.bind(this),
-          createReflectedValue: this.createReflectedValue.bind(this),
-          debug: this.debug.bind(this),
-          endRTrace: this.endRTrace.bind(this),
-          getRTraceAllocations: this.getRTraceAllocations.bind(this),
-          getRTraceBlocks: this.getRTraceBlocks.bind(this),
-          getRTraceCount: this.getRTraceCount.bind(this),
-          getRTraceDecrements: this.getRTraceDecrements.bind(this),
-          getRTraceFrees: this.getRTraceFrees.bind(this),
-          getRTraceGroupAllocations: this.getRTraceGroupAllocations.bind(this),
-          getRTraceGroupBlocks: this.getRTraceGroupBlocks.bind(this),
-          getRTraceGroupDecrements: this.getRTraceGroupDecrements.bind(this),
-          getRTraceGroupFrees: this.getRTraceGroupFrees.bind(this),
-          getRTraceGroupIncrements: this.getRTraceGroupIncrements.bind(this),
-          getRTraceGroupReallocs: this.getRTraceGroupReallocs.bind(this),
-          getRTraceIncrements: this.getRTraceIncrements.bind(this),
-          getRTraceReallocs: this.getRTraceReallocs.bind(this),
-          getRTraceTestAllocations: this.getRTraceTestAllocations.bind(this),
-          getRTraceTestBlocks: this.getRTraceTestBlocks.bind(this),
-          getRTraceTestDecrements: this.getRTraceTestDecrements.bind(this),
-          getRTraceTestFrees: this.getRTraceTestFrees.bind(this),
-          getRTraceTestIncrements: this.getRTraceTestIncrements.bind(this),
-          getRTraceTestReallocs: this.getRTraceTestReallocs.bind(this),
-          logReflectedValue: this.logReflectedValue.bind(this),
-          maxSamples: this.maxSamples.bind(this),
-          maxTestRunTime: this.maxTestRunTime.bind(this),
-          performanceEnabled: this.performanceEnabled.bind(this),
-          pushReflectedObjectKey: this.pushReflectedObjectKey.bind(this),
-          pushReflectedObjectValue: this.pushReflectedObjectValue.bind(this),
-          reportActualReflectedValue: this.reportActualReflectedValue.bind(
-            this,
-          ),
-          reportAfterAll: this.reportAfterAll.bind(this),
-          reportAfterEach: this.reportAfterEach.bind(this),
-          reportAverage: this.reportAverage.bind(this),
-          reportBeforeAll: this.reportBeforeAll.bind(this),
-          reportBeforeEach: this.reportBeforeEach.bind(this),
-          reportDescribe: this.reportDescribe.bind(this),
-          reportEndDescribe: this.reportEndDescribe.bind(this),
-          reportExpectedFalsy: this.reportExpectedFalsy.bind(this),
-          reportExpectedFinite: this.reportExpectedFinite.bind(this),
-          reportExpectedReflectedValue: this.reportExpectedReflectedValue.bind(
-            this,
-          ),
-          reportExpectedTruthy: this.reportExpectedTruthy.bind(this),
-          reportInvalidExpectCall: this.reportInvalidExpectCall.bind(this),
-          reportMax: this.reportMax.bind(this),
-          reportMedian: this.reportMedian.bind(this),
-          reportMin: this.reportMin.bind(this),
-          reportNegatedTest: this.reportNegatedTest.bind(this),
-          reportStdDev: this.reportStdDev.bind(this),
-          reportTest: this.reportTest.bind(this),
-          reportTodo: this.reportTodo.bind(this),
-          reportVariance: this.reportVariance.bind(this),
-          roundDecimalPlaces: this.roundDecimalPlaces.bind(this),
-          startRTrace: this.startRTrace.bind(this),
-          tryCall: this.tryCall.bind(this),
-        },
-      },
-    );
+    const finalImports: any = {};
+
+    for (const moduleImport of imports) {
+      for (const [key, value] of Object.entries(moduleImport)) {
+        /* istanbul ignore next */
+        if (key === "__aspect") continue;
+        /* istanbul ignore next */
+        finalImports[key] = Object.assign(finalImports[key] || {}, value);
+      }
+    }
+
+    finalImports.__aspect = {
+      attachStackTraceToReflectedValue: this.attachStackTraceToReflectedValue.bind(
+        this,
+      ),
+      clearActual: this.clearActual.bind(this),
+      clearExpected: this.clearExpected.bind(this),
+      createReflectedValue: this.createReflectedValue.bind(this),
+      debug: this.debug.bind(this),
+      endRTrace: this.endRTrace.bind(this),
+      getRTraceAllocations: this.getRTraceAllocations.bind(this),
+      getRTraceBlocks: this.getRTraceBlocks.bind(this),
+      getRTraceCount: this.getRTraceCount.bind(this),
+      getRTraceDecrements: this.getRTraceDecrements.bind(this),
+      getRTraceFrees: this.getRTraceFrees.bind(this),
+      getRTraceGroupAllocations: this.getRTraceGroupAllocations.bind(this),
+      getRTraceGroupBlocks: this.getRTraceGroupBlocks.bind(this),
+      getRTraceGroupDecrements: this.getRTraceGroupDecrements.bind(this),
+      getRTraceGroupFrees: this.getRTraceGroupFrees.bind(this),
+      getRTraceGroupIncrements: this.getRTraceGroupIncrements.bind(this),
+      getRTraceGroupReallocs: this.getRTraceGroupReallocs.bind(this),
+      getRTraceIncrements: this.getRTraceIncrements.bind(this),
+      getRTraceReallocs: this.getRTraceReallocs.bind(this),
+      getRTraceTestAllocations: this.getRTraceTestAllocations.bind(this),
+      getRTraceTestBlocks: this.getRTraceTestBlocks.bind(this),
+      getRTraceTestDecrements: this.getRTraceTestDecrements.bind(this),
+      getRTraceTestFrees: this.getRTraceTestFrees.bind(this),
+      getRTraceTestIncrements: this.getRTraceTestIncrements.bind(this),
+      getRTraceTestReallocs: this.getRTraceTestReallocs.bind(this),
+      logReflectedValue: this.logReflectedValue.bind(this),
+      maxSamples: this.maxSamples.bind(this),
+      maxTestRunTime: this.maxTestRunTime.bind(this),
+      performanceEnabled: this.performanceEnabled.bind(this),
+      pushReflectedObjectKey: this.pushReflectedObjectKey.bind(this),
+      pushReflectedObjectValue: this.pushReflectedObjectValue.bind(this),
+      reportActualReflectedValue: this.reportActualReflectedValue.bind(
+        this,
+      ),
+      reportAfterAll: this.reportAfterAll.bind(this),
+      reportAfterEach: this.reportAfterEach.bind(this),
+      reportAverage: this.reportAverage.bind(this),
+      reportBeforeAll: this.reportBeforeAll.bind(this),
+      reportBeforeEach: this.reportBeforeEach.bind(this),
+      reportDescribe: this.reportDescribe.bind(this),
+      reportEndDescribe: this.reportEndDescribe.bind(this),
+      reportExpectedFalsy: this.reportExpectedFalsy.bind(this),
+      reportExpectedFinite: this.reportExpectedFinite.bind(this),
+      reportExpectedReflectedValue: this.reportExpectedReflectedValue.bind(
+        this,
+      ),
+      reportExpectedTruthy: this.reportExpectedTruthy.bind(this),
+      reportInvalidExpectCall: this.reportInvalidExpectCall.bind(this),
+      reportMax: this.reportMax.bind(this),
+      reportMedian: this.reportMedian.bind(this),
+      reportMin: this.reportMin.bind(this),
+      reportNegatedTest: this.reportNegatedTest.bind(this),
+      reportStdDev: this.reportStdDev.bind(this),
+      reportTest: this.reportTest.bind(this),
+      reportTodo: this.reportTodo.bind(this),
+      reportVariance: this.reportVariance.bind(this),
+      roundDecimalPlaces: this.roundDecimalPlaces.bind(this),
+      startRTrace: this.startRTrace.bind(this),
+      tryCall: this.tryCall.bind(this),
+    };
 
     /** If RTrace is enabled, add it to the imports. */
-    if (this.rtraceEnabled)
-      result.rtrace = {
+    if (this.rtraceEnabled) {
+      finalImports.rtrace = {
         onalloc: this.onalloc.bind(this),
         onfree: this.onfree.bind(this),
         onincrement: this.onincrement.bind(this),
         ondecrement: this.ondecrement.bind(this),
         onrealloc: this.onrealloc.bind(this),
       };
+    }
 
     /** add an env object */
-    result.env = result.env || {};
+    finalImports.env = finalImports.env || {};
 
     /** Override the abort function */
-    const previousAbort = result.env.abort || (() => {});
-    result.env.abort = (...args: any[]) => {
+    const previousAbort = finalImports.env.abort || (() => {});
+    finalImports.env.abort = (...args: any[]) => {
       previousAbort(...args);
       // @ts-ignore
       this.abort(...args);
     };
     /** Override trace completely. */
-    result.env.trace = this.trace.bind(this);
+    finalImports.env.trace = this.trace.bind(this);
 
-    return result;
+    return finalImports;
   }
 
   /**


### PR DESCRIPTION
fixes #232 

This remains backwards compatible for everyone except for those who started to use the `WebAssembly.Memory` with the imports callback. Now those functions require that the configuration function returns an AssemblyScript module instead of the imports.