### PR TITLE
remove isDefined for unchecked, code coverage problem, long.js usage

### DIFF
--- a/packages/assembly/assembly/__tests__/toBe.spec.wat
+++ b/packages/assembly/assembly/__tests__/toBe.spec.wat
@@ -5850,7 +5850,7 @@
   else
    i32.const 0
    i32.const 2912
-   i32.const 438
+   i32.const 425
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -5862,7 +5862,7 @@
   else
    i32.const 0
    i32.const 2912
-   i32.const 438
+   i32.const 425
    i32.const 38
    call $~lib/builtins/abort
    unreachable

--- a/packages/assembly/assembly/__tests__/toStrictEqual.spec.wat
+++ b/packages/assembly/assembly/__tests__/toStrictEqual.spec.wat
@@ -6131,7 +6131,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -6143,7 +6143,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 38
    call $~lib/builtins/abort
    unreachable
@@ -10978,7 +10978,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -10990,7 +10990,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 38
    call $~lib/builtins/abort
    unreachable
@@ -12291,7 +12291,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -12303,7 +12303,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 38
    call $~lib/builtins/abort
    unreachable
@@ -12679,7 +12679,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -12691,7 +12691,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 38
    call $~lib/builtins/abort
    unreachable
@@ -30132,7 +30132,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -30144,7 +30144,7 @@
   else
    i32.const 0
    i32.const 3328
-   i32.const 438
+   i32.const 425
    i32.const 38
    call $~lib/builtins/abort
    unreachable

--- a/packages/assembly/assembly/internal/Reflect.ts
+++ b/packages/assembly/assembly/internal/Reflect.ts
@@ -321,29 +321,15 @@ export class Reflect {
         // loop over each array item and push it to the reflected value
         for (let i = 0; i < length; i++) {
           // @ts-ignore: index signature in arraylike
-          if (isDefined(unchecked(value[0]))) {
-            // @ts-ignore: index signature in arraylike
-            let arrayValue = unchecked(value[i]);
-            let reflectedArrayValueID = Reflect.toReflectedValue(
-              arrayValue,
-              seen,
-            );
-            __aspectPushReflectedObjectValue(
-              reflectedValue,
-              reflectedArrayValueID,
-            );
-          } else {
-            // @ts-ignore: index signature in arraylike
-            let arrayValue = value[i];
-            let reflectedArrayValueID = Reflect.toReflectedValue(
-              arrayValue,
-              seen,
-            );
-            __aspectPushReflectedObjectValue(
-              reflectedValue,
-              reflectedArrayValueID,
-            );
-          }
+          let arrayValue = unchecked(value[i]);
+          let reflectedArrayValueID = Reflect.toReflectedValue(
+            arrayValue,
+            seen,
+          );
+          __aspectPushReflectedObjectValue(
+            reflectedValue,
+            reflectedArrayValueID,
+          );
         }
         return reflectedValue;
       } else {
@@ -386,6 +372,7 @@ export class Reflect {
         nameof<T>(),
         // @ts-ignore: value is a 64 bit number
         <i32>(value >>> 32),
+        // @ts-ignore: value is a 64 bit number
         <i32>(value & 0xffffffff),
       );
 
@@ -614,6 +601,7 @@ function referencesEqual<T>(
     }
 
     // compile time array values should be compared over a for loop
+    // @ts-ignore: typesafe access to length
     if (isDefined(left.length)) {
       // @ts-ignore: typesafe access to length
       let aLength = left.length;
@@ -625,27 +613,15 @@ function referencesEqual<T>(
 
       // check each item
       for (let i = 0; i < aLength; i++) {
-        if (isDefined(unchecked(left[0]))) {
-          let result = Reflect.equals(
-            // @ts-ignore: typesafe and runtime check safe array access
-            unchecked(left[i]),
-            // @ts-ignore: typesafe and runtime check safe array access
-            unchecked(right[i]),
-            stack,
-            cache,
-          );
-          if (result == Reflect.FAILED_MATCH) return Reflect.FAILED_MATCH;
-        } else {
-          let result = Reflect.equals(
-            // @ts-ignore: typesafe and runtime check safe array access
-            left[i],
-            // @ts-ignore: typesafe and runtime check safe array access
-            right[i],
-            stack,
-            cache,
-          );
-          if (result == Reflect.FAILED_MATCH) return Reflect.FAILED_MATCH;
-        }
+        let result = Reflect.equals(
+          // @ts-ignore: typesafe and runtime check safe array access
+          unchecked(left[i]),
+          // @ts-ignore: typesafe and runtime check safe array access
+          unchecked(right[i]),
+          stack,
+          cache,
+        );
+        if (result == Reflect.FAILED_MATCH) return Reflect.FAILED_MATCH;
       }
 
       // cache this result

--- a/packages/assembly/assembly/internal/Reflect.ts
+++ b/packages/assembly/assembly/internal/Reflect.ts
@@ -371,9 +371,9 @@ export class Reflect {
         ReflectedValueType.Integer,
         nameof<T>(),
         // @ts-ignore: value is a 64 bit number
-        <i32>(value >>> 32),
-        // @ts-ignore: value is a 64 bit number
         <i32>(value & 0xffffffff),
+        // @ts-ignore: value is a 64 bit number
+        <i32>(value >>> 32),
       );
 
       return reflectedValue;

--- a/packages/core/__tests__/__snapshots__/SummaryReporter.fail.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/SummaryReporter.fail.spec.ts.snap
@@ -21,8 +21,7 @@ exports[`snapshots: onFinish assembly/jest-reporter.ts 1`] = `
   }
       [Expected]: \\"Serializes to same value.\\"
    [Error]: ReflectedValue Cannot log ReflectedValue of id -1. Index out of bounds.
-   [Stack]:     at start:assembly/jest-reporter-fail~anonymous|0~anonymous|3 (wasm-function[63]:0x16f4)
-               at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
 
 "
 `;

--- a/packages/core/__tests__/__snapshots__/TestContext.log.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/TestContext.log.spec.ts.snap
@@ -291,7 +291,7 @@ ReflectedValue {
   "type": 7,
   "typeId": 0,
   "typeName": "i64",
-  "value": "5652756399868872984",
+  "value": "9999999999999",
   "values": null,
 }
 `;
@@ -331,7 +331,7 @@ ReflectedValue {
   "type": 7,
   "typeId": 0,
   "typeName": "u64",
-  "value": "-3124073178620493592",
+  "value": "999999999999",
   "values": null,
 }
 `;
@@ -4957,11 +4957,11 @@ exports[`log output Group: logs Test: logs: stringify 6`] = `
   ]"
 `;
 
-exports[`log output Group: logs Test: logs: stringify 7`] = `"  number: 5652756399868872984 keyword: as class: i64"`;
+exports[`log output Group: logs Test: logs: stringify 7`] = `"  number: 9999999999999 keyword: as class: i64"`;
 
 exports[`log output Group: logs Test: logs: stringify 8`] = `"  number: 1234567 keyword: as class: u32"`;
 
-exports[`log output Group: logs Test: logs: stringify 9`] = `"  number: -3124073178620493592 keyword: as class: u64"`;
+exports[`log output Group: logs Test: logs: stringify 9`] = `"  number: 999999999999 keyword: as class: u64"`;
 
 exports[`log output Group: logs Test: logs: stringify 10`] = `"  number: -1 keyword: as class: i8"`;
 
@@ -5453,7 +5453,7 @@ ReflectedValue {
   "type": 7,
   "typeId": 0,
   "typeName": "i64",
-  "value": "5652756399868872984",
+  "value": "9999999999999",
   "values": null,
 }
 `;
@@ -5493,7 +5493,7 @@ ReflectedValue {
   "type": 7,
   "typeId": 0,
   "typeName": "u64",
-  "value": "-3124073178620493592",
+  "value": "999999999999",
   "values": null,
 }
 `;

--- a/packages/core/__tests__/__snapshots__/TestContext.pass-fail.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/TestContext.pass-fail.spec.ts.snap
@@ -1507,12 +1507,12 @@ ReflectedValue {
   "type": 7,
   "typeId": 0,
   "typeName": "i64",
-  "value": "12390559269718589437",
+  "value": "18446744063709551617",
   "values": null,
 }
 `;
 
-exports[`pass-fail output Node: !~pass-fail[0]!~should report long values[0]: actual-stringify 1`] = `"  number: 12390559269718589437 keyword: as class: i64"`;
+exports[`pass-fail output Node: !~pass-fail[0]!~should report long values[0]: actual-stringify 1`] = `"  number: 18446744063709551617 keyword: as class: i64"`;
 
 exports[`pass-fail output Node: !~pass-fail[0]!~should report long values[0]: afterAllPointers 1`] = `0`;
 
@@ -1541,12 +1541,12 @@ ReflectedValue {
   "type": 7,
   "typeId": 0,
   "typeName": "i64",
-  "value": "6056184808285929474",
+  "value": "9999999999",
   "values": null,
 }
 `;
 
-exports[`pass-fail output Node: !~pass-fail[0]!~should report long values[0]: expected-stringify 1`] = `"  number: 6056184808285929474 keyword: as class: i64"`;
+exports[`pass-fail output Node: !~pass-fail[0]!~should report long values[0]: expected-stringify 1`] = `"  number: 9999999999 keyword: as class: i64"`;
 
 exports[`pass-fail output Node: !~pass-fail[0]!~should report long values[0]: frees 1`] = `6`;
 

--- a/packages/core/__tests__/__snapshots__/VerboseReporter.fail.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/VerboseReporter.fail.spec.ts.snap
@@ -3,8 +3,7 @@
 exports[`snapshots: onFinish assembly/jest-reporter.ts 1`] = `
 "
    [Error]: ReflectedValue Cannot log ReflectedValue of id -1. Index out of bounds.
-   [Stack]:     at start:assembly/jest-reporter-fail~anonymous|0~anonymous|3 (wasm-function[63]:0x16f4)
-               at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
     [File]: assembly/jest-reporter.ts RTrace: +10
   [Groups]: 2 pass, 2 total
   [Result]: ✖ FAIL
@@ -29,10 +28,7 @@ exports[`snapshots: onGroupStart examples 1`] = `
 "[Describe]: examples
 
      [Log]: \\"testing in a group\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[43]:0x11f1)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[61]:0x16dd)
-            at start:assembly/jest-reporter-fail~anonymous|0 (wasm-function[121]:0x32f6)
-            at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
 "
 `;
 
@@ -49,15 +45,13 @@ exports[`snapshots: onTestFinish examples example 1 2`] = `
 exports[`snapshots: onTestFinish examples log value 1`] = `
 " [Success]: ✔ log value
      [Log]: \\"testing in a test\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[43]:0x11f1)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[61]:0x16dd)
-            at start:assembly/jest-reporter-fail~anonymous|0~anonymous|2 (wasm-function[62]:0x16ed)
-            at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
 "
 `;
 
 exports[`snapshots: onTestFinish examples push an error to the error array 1`] = `
 "    [Fail]: ✖ push an error to the error array
+   [Stack]: No Stack Trace
 "
 `;
 
@@ -66,11 +60,7 @@ exports[`snapshots: onTestFinish examples something fails 1`] = `
   [Actual]: -1
 [Expected]: 42
  [Message]: Here is an example failure message.
-   [Stack]: RuntimeError: unreachable
-            at ../assembly/assembly/internal/assert/assert (wasm-function[46]:0x124e)
-            at ../assembly/assembly/internal/Expectation/Expectation<i32>#toBe (wasm-function[49]:0x1296)
-            at start:assembly/jest-reporter-fail~anonymous|0~anonymous|4 (wasm-function[64]:0x1706)
-            at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
 "
 `;
 
@@ -79,16 +69,9 @@ exports[`snapshots: onTestFinish examples something negated fails 1`] = `
   [Actual]: 42
 [Expected]: Not 42
  [Message]: 42 is 42
-   [Stack]: RuntimeError: unreachable
-            at ../assembly/assembly/internal/assert/assert (wasm-function[46]:0x124e)
-            at ../assembly/assembly/internal/Expectation/Expectation<i32>#toBe (wasm-function[49]:0x1296)
-            at start:assembly/jest-reporter-fail~anonymous|0~anonymous|7 (wasm-function[98]:0x2a93)
-            at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
      [Log]: \\"another string\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[43]:0x11f1)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[61]:0x16dd)
-            at start:assembly/jest-reporter-fail~anonymous|0~anonymous|7 (wasm-function[98]:0x2a82)
-            at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
 "
 `;
 
@@ -101,17 +84,14 @@ exports[`snapshots: onTestFinish examples something using toBe fails with a refe
   }
 [Expected]: \\"Serializes to same value.\\"
  [Message]: not the same pointer
-   [Stack]: RuntimeError: unreachable
-            at ../assembly/assembly/internal/assert/assert (wasm-function[46]:0x124e)
-            at ../assembly/assembly/internal/Expectation/Expectation<assembly/jest-reporter-fail/Vec3>#toBe (wasm-function[119]:0x3251)
-            at start:assembly/jest-reporter-fail~anonymous|0~anonymous|8 (wasm-function[120]:0x3299)
-            at ../assembly/assembly/internal/call/__call (wasm-function[124]:0x330f)
+   [Stack]: Has Stack Trace
 "
 `;
 
 exports[`snapshots: onTestFinish examples this should throw but it does not 1`] = `
 "    [Fail]: ✖ this should throw but it does not
  [Message]: it should throw
+   [Stack]: Has Stack Trace
 "
 `;
 

--- a/packages/core/__tests__/__snapshots__/VerboseReporter.pass.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/VerboseReporter.pass.spec.ts.snap
@@ -24,10 +24,7 @@ exports[`snapshots: onGroupStart a passing suite 1`] = `
 "[Describe]: a passing suite
 
      [Log]: \\"Something else!\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[43]:0x1430)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[44]:0x145e)
-            at start:assembly/jest-reporter-pass~anonymous|0 (wasm-function[58]:0x15ed)
-            at ../assembly/assembly/internal/call/__call (wasm-function[61]:0x1617)
+   [Stack]: Has Stack Trace
 "
 `;
 
@@ -39,10 +36,7 @@ exports[`snapshots: onTestFinish a passing suite it throws successfully! 1`] = `
 exports[`snapshots: onTestFinish a passing suite passes 1`] = `
 " [Success]: ✔ passes
      [Log]: \\"Something!\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[43]:0x1430)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[44]:0x145e)
-            at start:assembly/jest-reporter-pass~anonymous|0~anonymous|0 (wasm-function[55]:0x15b5)
-            at ../assembly/assembly/internal/call/__call (wasm-function[61]:0x1617)
+   [Stack]: Has Stack Trace
 "
 `;
 

--- a/packages/core/__tests__/__snapshots__/VerboseReporter.snapshot.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/VerboseReporter.snapshot.spec.ts.snap
@@ -47,91 +47,45 @@ exports[`snapshots: onGroupStart logs 1`] = `
 "[Describe]: logs
 
      [Log]: \\"Hello world!\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[52]:0x1751)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x745f)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: 42
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i32> (wasm-function[55]:0x17cd)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x7463)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: <Vec3>null
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/Vec3 | null> (wasm-function[67]:0x24a2)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x7467)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Vec3 {
                 x: 1.0,
                 y: 2.0,
                 z: 3.0
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/Vec3> (wasm-function[71]:0x25e6)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x748a)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Array<i32> [
                 1,
                 2,
                 3
             ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/array/Array<i32>> (wasm-function[77]:0x277a)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x749b)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: 5652756399868872984 as i64
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i64> (wasm-function[80]:0x2803)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74a5)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: 1234567 as u32
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<u32> (wasm-function[83]:0x287b)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74ac)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: -3124073178620493592 as u64
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<u64> (wasm-function[86]:0x2900)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74b5)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: -1 as i8
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i8> (wasm-function[89]:0x2978)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74b9)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: -1 as i16
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i16> (wasm-function[92]:0x29f0)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74bd)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: true
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<bool> (wasm-function[95]:0x2a68)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74c1)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: false
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<bool> (wasm-function[95]:0x2a68)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74c5)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Uint8Array [ 0, 1, 2 ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/typedarray/Uint8Array> (wasm-function[101]:0x2bdd)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74c9)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Int8Array [ -1, -2, -3 ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/typedarray/Int8Array> (wasm-function[106]:0x2d30)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74cd)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: [Function 1: ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<(i: i32) => i32> (wasm-function[109]:0x2dea)
-            at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x74d1)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: \\"trace: The thing! 1, 2, 3, 4, 5\\"
-   [Stack]: at start:assembly/jest-log~anonymous|0 (wasm-function[294]:0x7505)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
 "
 `;
 
@@ -144,105 +98,53 @@ exports[`snapshots: onGroupStart snapshots 1`] = `
 exports[`snapshots: onTestFinish logs logs 1`] = `
 " [Success]: ✔ logs RTrace: +4
      [Log]: \\"Hello world!\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[52]:0x1751)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x70ae)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: \\"Calculated 42\\"
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/string/String> (wasm-function[52]:0x1751)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x70bd)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: 42
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i32> (wasm-function[55]:0x17cd)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x70c1)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: <Vec3>null
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/Vec3 | null> (wasm-function[67]:0x24a2)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x70c5)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Vec3 {
                 x: 1.0,
                 y: 2.0,
                 z: 3.0
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/Vec3> (wasm-function[71]:0x25e6)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x70e8)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Array<i32> [
                 1,
                 2,
                 3
             ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/array/Array<i32>> (wasm-function[77]:0x277a)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x70f9)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: 5652756399868872984 as i64
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i64> (wasm-function[80]:0x2803)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7103)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: 1234567 as u32
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<u32> (wasm-function[83]:0x287b)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x710a)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: -3124073178620493592 as u64
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<u64> (wasm-function[86]:0x2900)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7113)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: -1 as i8
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i8> (wasm-function[89]:0x2978)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7117)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: -1 as i16
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<i16> (wasm-function[92]:0x29f0)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x711b)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: true
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<bool> (wasm-function[95]:0x2a68)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x711f)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: false
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<bool> (wasm-function[95]:0x2a68)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7123)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Uint8Array [ 0, 1, 2 ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/typedarray/Uint8Array> (wasm-function[101]:0x2bdd)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7127)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Int8Array [ -1, -2, -3 ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/typedarray/Int8Array> (wasm-function[106]:0x2d30)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x712b)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: [Function 1: ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<(i: i32) => i32> (wasm-function[109]:0x2dea)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x712f)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: \\"trace: The thing! 1, 2, 3, 4, 5\\"
-   [Stack]: at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7163)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: UnmanagedClass {
                 a: 1.0,
                 b: 2.0,
                 c: 3.0
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/UnmanagedClass> (wasm-function[121]:0x3264)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x716d)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Array<i32> [
                 0,
                 1,
@@ -265,10 +167,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                 18,
                 19
             ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/array/Array<i32>> (wasm-function[77]:0x277a)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x71a7)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: LotsOfFields {
                 a: 1.0,
                 b: 1.0,
@@ -297,34 +196,22 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                 y: 1.0,
                 z: 1.0
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/LotsOfFields> (wasm-function[134]:0x3bfe)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x71b0)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Float64Array [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0... +10 items ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/typedarray/Float64Array> (wasm-function[141]:0x3daf)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x71ea)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Array<i32> [
                 1,
                 2,
                 3
             ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/array/Array<i32>> (wasm-function[77]:0x277a)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x71fc)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Circular {
                 a: 1.0 as f32,
                 b: [Circular Reference],
                 c: 3.0 as f32,
                 d: <Array<assembly/jest-log/Circular>>null
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/Circular> (wasm-function[151]:0x41b5)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x722c)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Array<assembly/jest-log/Circular> [
                 {
                     a: 1.0 as f32,
@@ -333,10 +220,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     d: [Circular Reference]
                 }
             ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/array/Array<assembly/jest-log/Circular>> (wasm-function[156]:0x4373)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x726e)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedA {
                 a: NestedB {
                     b: NestedC {
@@ -344,23 +228,14 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     }
                 }
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedA> (wasm-function[176]:0x4a79)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7278)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Map<assembly/jest-log/Vec3,i32> {
                 [Vec3]: 42,
                 [Vec3]: 44
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/map/Map<assembly/jest-log/Vec3,i32>> (wasm-function[194]:0x51b7)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7308)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: [Function 2: ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<() => ~lib/string/String> (wasm-function[198]:0x527a)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x730d)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedForInlineFunctionA {
                 a: NestedForInlineFunctionB {
                     b: NestedForInlineFunctionC {
@@ -368,10 +243,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     }
                 }
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedForInlineFunctionA> (wasm-function[211]:0x5690)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7317)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedForInlineStringA {
                 a: NestedForInlineStringB {
                     b: NestedForInlineStringC {
@@ -379,10 +251,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     }
                 }
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedForInlineStringA> (wasm-function[222]:0x5a42)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7321)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedForInlineU8A {
                 a: NestedForInlineU8B {
                     b: NestedForInlineU8C {
@@ -390,10 +259,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     }
                 }
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedForInlineU8A> (wasm-function[233]:0x5df3)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x732b)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedForInlineBoolA {
                 a: NestedForInlineBoolB {
                     b: NestedForInlineBoolC {
@@ -401,10 +267,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     }
                 }
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedForInlineBoolA> (wasm-function[244]:0x61a4)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7335)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedForInlineBoolA {
                 a: NestedForInlineBoolB {
                     b: NestedForInlineBoolC {
@@ -412,10 +275,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     }
                 }
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedForInlineBoolA> (wasm-function[244]:0x61a4)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x734e)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedTypeImpliedArrayA {
                 a: NestedTypeImpliedArrayB {
                     b: NestedTypeImpliedArrayC {
@@ -423,10 +283,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     }
                 }
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedTypeImpliedArrayA> (wasm-function[261]:0x6777)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7358)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: NestedTypeImpliedArrayC {
                 c: Array<~lib/array/Array<u8>> [
                     [
@@ -434,10 +291,7 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     ]
                 ]
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/NestedTypeImpliedArrayC> (wasm-function[263]:0x67de)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x7362)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Array<assembly/jest-log/Vec3> [
                 {
                     x: 1.0,
@@ -460,34 +314,22 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                     z: 3.0
                 }
             ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/array/Array<assembly/jest-log/Vec3>> (wasm-function[267]:0x6970)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x73bd)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Array<assembly/jest-log/Vec3 | null> [
                 null
             ]
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<~lib/array/Array<assembly/jest-log/Vec3 | null>> (wasm-function[274]:0x6b48)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x73d3)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: MeaningOfLife {
                 its: 42
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/Overridden> (wasm-function[282]:0x6d62)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x73dd)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
      [Log]: Child {
                 a: 0,
                 c: 2,
                 b: 4,
                 d: 6
             }
-   [Stack]: at ../assembly/assembly/internal/Reflect/Reflect.attachStackTrace (wasm-function[51]:0x1723)
-            at ../assembly/assembly/internal/log/log<assembly/jest-log/Child> (wasm-function[292]:0x709b)
-            at start:assembly/jest-log~anonymous|0~anonymous|0 (wasm-function[293]:0x73e7)
-            at ../assembly/assembly/internal/call/__call (wasm-function[317]:0x78b1)
+   [Stack]: Has Stack Trace
 "
 `;
 

--- a/packages/core/__tests__/__snapshots__/VerboseReporter.snapshot.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/VerboseReporter.snapshot.spec.ts.snap
@@ -64,11 +64,11 @@ exports[`snapshots: onGroupStart logs 1`] = `
                 3
             ]
    [Stack]: Has Stack Trace
-     [Log]: 5652756399868872984 as i64
+     [Log]: 9999999999999 as i64
    [Stack]: Has Stack Trace
      [Log]: 1234567 as u32
    [Stack]: Has Stack Trace
-     [Log]: -3124073178620493592 as u64
+     [Log]: 999999999999 as u64
    [Stack]: Has Stack Trace
      [Log]: -1 as i8
    [Stack]: Has Stack Trace
@@ -117,11 +117,11 @@ exports[`snapshots: onTestFinish logs logs 1`] = `
                 3
             ]
    [Stack]: Has Stack Trace
-     [Log]: 5652756399868872984 as i64
+     [Log]: 9999999999999 as i64
    [Stack]: Has Stack Trace
      [Log]: 1234567 as u32
    [Stack]: Has Stack Trace
-     [Log]: -3124073178620493592 as u64
+     [Log]: 999999999999 as u64
    [Stack]: Has Stack Trace
      [Log]: -1 as i8
    [Stack]: Has Stack Trace

--- a/packages/core/__tests__/setup/SummaryReporterWrapper.ts
+++ b/packages/core/__tests__/setup/SummaryReporterWrapper.ts
@@ -1,5 +1,6 @@
 import { SummaryReporter, TestNode, TestContext } from "../../src";
 import stripAnsi from "strip-ansi";
+import { removeStackTraces } from "./removeStackTraces";
 
 export class SummaryReporterWrapper extends SummaryReporter {
   public writer: any;
@@ -21,6 +22,7 @@ export class SummaryReporterWrapper extends SummaryReporter {
   }
   onGroupStart(group: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
     super.onGroupStart(group);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onGroupStart ${group.name}`, result);
@@ -28,6 +30,7 @@ export class SummaryReporterWrapper extends SummaryReporter {
   }
   onGroupFinish(group: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
     super.onGroupFinish(group);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onGroupEnd ${group.name}`, result);
@@ -35,6 +38,8 @@ export class SummaryReporterWrapper extends SummaryReporter {
   }
   onTestStart(group: TestNode, testResult: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
+    removeStackTraces(testResult);
     super.onTestStart(group, testResult);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onTestStart ${group.name} ${testResult.name}`, result);
@@ -42,6 +47,8 @@ export class SummaryReporterWrapper extends SummaryReporter {
   }
   onTestFinish(group: TestNode, testResult: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
+    removeStackTraces(testResult);
     super.onTestFinish(group, testResult);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onTestFinish ${group.name} ${testResult.name}`, result);
@@ -55,6 +62,9 @@ export class SummaryReporterWrapper extends SummaryReporter {
     });
     ctx.rootNode.start = 0;
     ctx.rootNode.end = 0;
+    ctx.errors.forEach((e) => {
+      e.stackTrace = e.stackTrace ? "Has Stack Trace" : "No Stack Trace";
+    });
     super.onFinish(ctx);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onFinish ${ctx.fileName}`, result);

--- a/packages/core/__tests__/setup/VerboseReporterWrapper.ts
+++ b/packages/core/__tests__/setup/VerboseReporterWrapper.ts
@@ -1,5 +1,6 @@
 import { VerboseReporter, TestNode, TestContext } from "../../src";
 import stripAnsi from "strip-ansi";
+import { removeStackTraces } from "./removeStackTraces";
 
 export class VerboseReporterWrapper extends VerboseReporter {
   public writer: any;
@@ -25,6 +26,7 @@ export class VerboseReporterWrapper extends VerboseReporter {
   }
   onGroupStart(group: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
     super.onGroupStart(group);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onGroupStart ${group.name}`, result);
@@ -32,6 +34,7 @@ export class VerboseReporterWrapper extends VerboseReporter {
   }
   onGroupFinish(group: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
     // @ts-ignore
     super.onGroupFinish(group);
     const result = stripAnsi(this.writer.result);
@@ -40,6 +43,8 @@ export class VerboseReporterWrapper extends VerboseReporter {
   }
   onTestStart(group: TestNode, testResult: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
+    removeStackTraces(testResult);
     super.onTestStart(group, testResult);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onTestStart ${group.name} ${testResult.name}`, result);
@@ -47,6 +52,8 @@ export class VerboseReporterWrapper extends VerboseReporter {
   }
   onTestFinish(group: TestNode, testResult: TestNode): void {
     this.writer.reset();
+    removeStackTraces(group);
+    removeStackTraces(testResult);
     super.onTestFinish(group, testResult);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onTestFinish ${group.name} ${testResult.name}`, result);
@@ -60,6 +67,9 @@ export class VerboseReporterWrapper extends VerboseReporter {
     });
     ctx.rootNode.start = 0;
     ctx.rootNode.end = 0;
+    ctx.errors.forEach((e) => {
+      e.stackTrace = e.stackTrace ? "Has Stack Trace" : "No Stack Trace";
+    });
     super.onFinish(ctx);
     const result = stripAnsi(this.writer.result);
     this.addSnapshot(`onFinish ${ctx.fileName}`, result);

--- a/packages/core/__tests__/setup/removeStackTraces.ts
+++ b/packages/core/__tests__/setup/removeStackTraces.ts
@@ -1,0 +1,11 @@
+import { TestNode } from "../../src";
+
+export function removeStackTraces(node: TestNode): void {
+  node.logs.forEach((e) => {
+    e.stack = e.stack ? "Has Stack Trace" : "No Stack Trace";
+  });
+  node.errors.forEach((e) => {
+    e.stackTrace = e.stackTrace ? "Has Stack Trace" : "No Stack Trace";
+  });
+  node.stackTrace = node.stackTrace ? "Has Stack Trace" : "No Stack Trace";
+}

--- a/packages/core/src/test/TestContext.ts
+++ b/packages/core/src/test/TestContext.ts
@@ -550,10 +550,7 @@ export class TestContext {
    * @param {number} description - The test suite description string pointer.
    * @param {number} runner - The pointer to a test suite callback
    */
-  private reportGroupTypeNode(
-    description: number,
-    runner: number,
-  ): void {
+  private reportGroupTypeNode(description: number, runner: number): void {
     this.reportTestNode(TestNodeType.Group, description, runner, 0, 0);
   }
 

--- a/packages/core/src/test/TestContext.ts
+++ b/packages/core/src/test/TestContext.ts
@@ -551,8 +551,8 @@ export class TestContext {
    * @param {number} runner - The pointer to a test suite callback
    */
   private reportGroupTypeNode(
-    description: number = 0,
-    runner: number = 0,
+    description: number,
+    runner: number,
   ): void {
     this.reportTestNode(TestNodeType.Group, description, runner, 0, 0);
   }
@@ -577,7 +577,7 @@ export class TestContext {
   private reportNegatedTestNode(
     description: number,
     runner: number,
-    message: number = 0,
+    message: number,
   ): void {
     this.reportTestNode(TestNodeType.Test, description, runner, 1, message);
   }


### PR DESCRIPTION
`unchecked()` is always safe here, since it always defaults to regular checked gets if the operator doesn't exist. I also remove a few default parameters because they are handled in AssemblyScript.