### PR TITLE
Fix toHaveLength, update packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "version": "file:packages/cli",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^3.1.6",
-        "@as-pect/core": "^3.1.6",
-        "@as-pect/csv-reporter": "^3.1.6",
-        "@as-pect/json-reporter": "^3.1.6",
+        "@as-pect/assembly": "^3.2.0",
+        "@as-pect/core": "^3.2.0",
+        "@as-pect/csv-reporter": "^3.2.0",
+        "@as-pect/json-reporter": "^3.2.0",
         "chalk": "^4.0.0",
         "glob": "^7.1.6"
       }
@@ -23,8 +23,8 @@
       "version": "file:packages/core",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^3.1.6",
-        "@as-pect/snapshots": "^3.1.6",
+        "@as-pect/assembly": "^3.2.0",
+        "@as-pect/snapshots": "^3.2.0",
         "chalk": "^4.0.0",
         "long": "^4.0.0"
       }
@@ -33,14 +33,14 @@
       "version": "file:packages/csv-reporter",
       "dev": true,
       "requires": {
-        "@as-pect/core": "^3.1.6"
+        "@as-pect/core": "^3.2.0"
       }
     },
     "@as-pect/json-reporter": {
       "version": "file:packages/json-reporter",
       "dev": true,
       "requires": {
-        "@as-pect/core": "^3.1.6"
+        "@as-pect/core": "^3.2.0"
       }
     },
     "@as-pect/snapshots": {

--- a/packages/assembly/assembly/__tests__/toHaveLength.spec.wat
+++ b/packages/assembly/assembly/__tests__/toHaveLength.spec.wat
@@ -1,26 +1,17 @@
 (module
  (type $none_=>_none (func))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
- (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
- (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
- (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
- (type $i32_i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32 i32) (result i32)))
- (type $i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_f64_=>_i32 (func (param i32 i32 i32 i32 f64) (result i32)))
- (type $f32_i32_=>_i32 (func (param f32 i32) (result i32)))
- (type $f64_i32_=>_i32 (func (param f64 i32) (result i32)))
- (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
- (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
  (import "env" "memory" (memory $0 1))
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -32,59 +23,41 @@
  (data (i32.const 352) ":\00\00\00\01\00\00\00\01\00\00\00:\00\00\00s\00h\00o\00u\00l\00d\00 \00a\00s\00s\00e\00r\00t\00 \00e\00x\00p\00e\00c\00t\00e\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 432) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 480) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 544) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00K\00e\00y\00 \00d\00o\00e\00s\00 \00n\00o\00t\00 \00e\00x\00i\00s\00t\00")
- (data (i32.const 608) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00~\00l\00i\00b\00/\00m\00a\00p\00.\00t\00s\00")
- (data (i32.const 656) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\00u\008\00")
- (data (i32.const 688) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00i\003\002\00")
- (data (i32.const 720) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00a\00s\00s\00e\00r\00t\00.\00t\00s\00")
- (data (i32.const 800) "h\00\00\00\01\00\00\00\01\00\00\00h\00\00\00w\00h\00e\00n\00 \00e\00x\00p\00e\00c\00t\00e\00d\00 \00l\00e\00n\00g\00t\00h\00 \00s\00h\00o\00u\00l\00d\00 \00n\00o\00t\00 \00e\00q\00u\00a\00l\00 \00t\00h\00e\00 \00s\00a\00m\00e\00 \00v\00a\00l\00u\00e\00")
- (data (i32.const 928) "l\00\00\00\01\00\00\00\01\00\00\00l\00\00\00W\00h\00e\00n\00 \00l\00e\00n\00g\00t\00h\00 \00i\00s\00 \00e\00q\00u\00a\00l\00,\00 \00n\00e\00g\00a\00t\00e\00d\00 \00a\00s\00s\00e\00r\00t\00i\00o\00n\00s\00 \00s\00h\00o\00u\00l\00d\00 \00t\00h\00r\00o\00w\00.\00")
- (data (i32.const 1056) "Z\00\00\00\01\00\00\00\01\00\00\00Z\00\00\00s\00h\00o\00u\00l\00d\00 \00v\00e\00r\00i\00f\00y\00 \00t\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00i\00s\00 \00n\00o\00t\00 \00a\00n\00o\00t\00h\00e\00r\00 \00v\00a\00l\00u\00e\00")
- (data (i32.const 1168) "F\00\00\00\01\00\00\00\01\00\00\00F\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00r\00e\00a\00t\00e\00d\00 \00i\00s\00 \003\00,\00 \00n\00o\00t\00 \001\000\00.\00")
- (data (i32.const 1264) "R\00\00\00\01\00\00\00\01\00\00\00R\00\00\00w\00h\00e\00n\00 \00t\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00i\00s\00 \00a\00n\00o\00t\00h\00e\00r\00 \00e\00x\00p\00e\00c\00t\00e\00d\00 \00v\00a\00l\00u\00e\00")
- (data (i32.const 1376) "L\00\00\00\01\00\00\00\01\00\00\00L\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00r\00e\00a\00t\00e\00d\00 \00i\00s\00 \003\00,\00 \00a\00n\00d\00 \00n\00o\00t\00 \001\000\00")
- (data (i32.const 1472) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00U\00i\00n\00t\008\00C\00l\00a\00m\00p\00e\00d\00A\00r\00r\00a\00y\00")
- (data (i32.const 1536) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00I\00n\00t\008\00A\00r\00r\00a\00y\00")
- (data (i32.const 1584) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\00i\008\00")
- (data (i32.const 1616) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00U\00i\00n\00t\001\006\00A\00r\00r\00a\00y\00")
- (data (i32.const 1664) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00u\001\006\00")
- (data (i32.const 1696) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00I\00n\00t\001\006\00A\00r\00r\00a\00y\00")
- (data (i32.const 1744) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00i\001\006\00")
- (data (i32.const 1776) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00U\00i\00n\00t\003\002\00A\00r\00r\00a\00y\00")
- (data (i32.const 1824) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00u\003\002\00")
- (data (i32.const 1856) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00I\00n\00t\003\002\00A\00r\00r\00a\00y\00")
- (data (i32.const 1904) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00U\00i\00n\00t\006\004\00A\00r\00r\00a\00y\00")
- (data (i32.const 1952) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00u\006\004\00")
- (data (i32.const 1984) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00I\00n\00t\006\004\00A\00r\00r\00a\00y\00")
- (data (i32.const 2032) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00i\006\004\00")
- (data (i32.const 2064) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00F\00l\00o\00a\00t\003\002\00A\00r\00r\00a\00y\00")
- (data (i32.const 2112) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00f\003\002\00")
- (data (i32.const 2144) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00F\00l\00o\00a\00t\006\004\00A\00r\00r\00a\00y\00")
- (data (i32.const 2192) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00f\006\004\00")
- (data (i32.const 2224) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
- (data (i32.const 2256) "\10\00\00\00\01\00\00\00\1a\00\00\00\10\00\00\00\c0\08\00\00\c0\08\00\00\0c\00\00\00\03\00\00\00")
- (data (i32.const 2288) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00t\00o\00H\00a\00v\00e\00L\00e\00n\00g\00t\00h\00 \00A\00r\00r\00a\00y\00s\00")
- (data (i32.const 2352) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00A\00r\00r\00a\00y\00<\00i\003\002\00>\00")
- (data (i32.const 2400) "\82\00\00\00\01\00\00\00\01\00\00\00\82\00\00\00s\00h\00o\00u\00l\00d\00 \00t\00h\00r\00o\00w\00 \00w\00h\00e\00n\00 \00e\00x\00p\00e\00c\00t\00e\00d\00 \00l\00e\00n\00g\00t\00h\00 \00s\00h\00o\00u\00l\00d\00 \00n\00o\00t\00 \00e\00q\00u\00a\00l\00 \00t\00h\00e\00 \00s\00a\00m\00e\00 \00v\00a\00l\00u\00e\00")
- (data (i32.const 2560) "L\00\00\00\01\00\00\00\01\00\00\00L\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00v\00a\00l\00u\00e\00A\00r\00r\00a\00y\00 \00i\00s\00 \003\00,\00 \00n\00o\00t\00 \001\000\00.\00")
- (data (i32.const 2656) "R\00\00\00\01\00\00\00\01\00\00\00R\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00v\00a\00l\00u\00e\00A\00r\00r\00a\00y\00 \00i\00s\00 \003\00,\00 \00a\00n\00d\00 \00n\00o\00t\00 \001\000\00")
- (data (i32.const 2768) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00t\00o\00H\00a\00v\00e\00L\00e\00n\00g\00t\00h\00 \00c\00u\00s\00t\00o\00m\00 \00c\00l\00a\00s\00s\00e\00s\00")
- (data (i32.const 2848) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\00E\00x\00a\00m\00p\00l\00e\00")
- (data (i32.const 2880) "\00\00\00\00\01\00\00\00\1e\00\00\00\00\00\00\00")
- (data (i32.const 2896) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 2928) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00S\00t\00r\00i\00n\00g\00")
- (data (i32.const 2960) "R\00\00\00\01\00\00\00\01\00\00\00R\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00u\00s\00t\00o\00m\00E\00x\00a\00m\00p\00l\00e\00 \00i\00s\00 \003\00,\00 \00n\00o\00t\00 \001\000\00.\00")
- (data (i32.const 3072) "X\00\00\00\01\00\00\00\01\00\00\00X\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00u\00s\00t\00o\00m\00E\00x\00a\00m\00p\00l\00e\00 \00i\00s\00 \003\00,\00 \00a\00n\00d\00 \00n\00o\00t\00 \001\000\00")
- (data (i32.const 3184) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00A\00r\00r\00a\00y\00B\00u\00f\00f\00e\00r\00")
- (data (i32.const 3232) "D\00\00\00\01\00\00\00\01\00\00\00D\00\00\00s\00h\00o\00u\00l\00d\00 \00c\00o\00m\00p\00a\00r\00e\00 \00A\00r\00r\00a\00y\00B\00u\00f\00f\00e\00r\00 \00l\00e\00n\00g\00t\00h\00s\00")
- (data (i32.const 3328) "n\00\00\00\01\00\00\00\01\00\00\00n\00\00\00A\00n\00 \00a\00r\00r\00a\00y\00 \00b\00u\00f\00f\00e\00r\00 \00w\00i\00t\00h\00 \00l\00e\00n\00g\00t\00h\00 \001\000\000\00 \00s\00h\00o\00u\00l\00d\00 \00h\00a\00v\00e\00 \00l\00e\00n\00g\00t\00h\00 \001\000\000\00.\00")
- (data (i32.const 3456) "!\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00a\00\00\00\02\00\00\00 \00\00\00\00\00\00\000\t\02\00\00\00\00\00a\00\00\00\02\00\00\00 \00\00\00\00\00\00\00a\08\00\00\02\00\00\00 \00\00\00\00\00\00\00\a1\00\00\00\02\00\00\00 \00\00\00\00\00\00\00\a1\08\00\00\02\00\00\00 \00\00\00\00\00\00\00!\01\00\00\02\00\00\00 \00\00\00\00\00\00\00!\t\00\00\02\00\00\00 \00\00\00\00\00\00\00!\02\00\00\02\00\00\00 \00\00\00\00\00\00\00!\n\00\00\02\00\00\00 \00\00\00\00\00\00\00!\19\00\00\02\00\00\00 \00\00\00\00\00\00\00!\1a\00\00\02\00\00\00 \00\00\00\00\00\00\00\"\t\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00$\n\00\00\00\00\00\00 \00\00\00\00\00\00\00\"\01\00\00\00\00\00\00")
+ (data (i32.const 544) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00i\003\002\00")
+ (data (i32.const 576) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00a\00s\00s\00e\00r\00t\00.\00t\00s\00")
+ (data (i32.const 656) "h\00\00\00\01\00\00\00\01\00\00\00h\00\00\00w\00h\00e\00n\00 \00e\00x\00p\00e\00c\00t\00e\00d\00 \00l\00e\00n\00g\00t\00h\00 \00s\00h\00o\00u\00l\00d\00 \00n\00o\00t\00 \00e\00q\00u\00a\00l\00 \00t\00h\00e\00 \00s\00a\00m\00e\00 \00v\00a\00l\00u\00e\00")
+ (data (i32.const 784) "l\00\00\00\01\00\00\00\01\00\00\00l\00\00\00W\00h\00e\00n\00 \00l\00e\00n\00g\00t\00h\00 \00i\00s\00 \00e\00q\00u\00a\00l\00,\00 \00n\00e\00g\00a\00t\00e\00d\00 \00a\00s\00s\00e\00r\00t\00i\00o\00n\00s\00 \00s\00h\00o\00u\00l\00d\00 \00t\00h\00r\00o\00w\00.\00")
+ (data (i32.const 912) "Z\00\00\00\01\00\00\00\01\00\00\00Z\00\00\00s\00h\00o\00u\00l\00d\00 \00v\00e\00r\00i\00f\00y\00 \00t\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00i\00s\00 \00n\00o\00t\00 \00a\00n\00o\00t\00h\00e\00r\00 \00v\00a\00l\00u\00e\00")
+ (data (i32.const 1024) "F\00\00\00\01\00\00\00\01\00\00\00F\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00r\00e\00a\00t\00e\00d\00 \00i\00s\00 \003\00,\00 \00n\00o\00t\00 \001\000\00.\00")
+ (data (i32.const 1120) "R\00\00\00\01\00\00\00\01\00\00\00R\00\00\00w\00h\00e\00n\00 \00t\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00i\00s\00 \00a\00n\00o\00t\00h\00e\00r\00 \00e\00x\00p\00e\00c\00t\00e\00d\00 \00v\00a\00l\00u\00e\00")
+ (data (i32.const 1232) "L\00\00\00\01\00\00\00\01\00\00\00L\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00r\00e\00a\00t\00e\00d\00 \00i\00s\00 \003\00,\00 \00a\00n\00d\00 \00n\00o\00t\00 \001\000\00")
+ (data (i32.const 1328) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00U\00i\00n\00t\008\00C\00l\00a\00m\00p\00e\00d\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1392) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00I\00n\00t\008\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1440) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00U\00i\00n\00t\001\006\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1488) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00I\00n\00t\001\006\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1536) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00U\00i\00n\00t\003\002\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1584) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00I\00n\00t\003\002\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1632) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00U\00i\00n\00t\006\004\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1680) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00I\00n\00t\006\004\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1728) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00F\00l\00o\00a\00t\003\002\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1776) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00F\00l\00o\00a\00t\006\004\00A\00r\00r\00a\00y\00")
+ (data (i32.const 1824) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
+ (data (i32.const 1856) "\10\00\00\00\01\00\00\00\1a\00\00\00\10\00\00\000\07\00\000\07\00\00\0c\00\00\00\03\00\00\00")
+ (data (i32.const 1888) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00t\00o\00H\00a\00v\00e\00L\00e\00n\00g\00t\00h\00 \00A\00r\00r\00a\00y\00s\00")
+ (data (i32.const 1952) "\82\00\00\00\01\00\00\00\01\00\00\00\82\00\00\00s\00h\00o\00u\00l\00d\00 \00t\00h\00r\00o\00w\00 \00w\00h\00e\00n\00 \00e\00x\00p\00e\00c\00t\00e\00d\00 \00l\00e\00n\00g\00t\00h\00 \00s\00h\00o\00u\00l\00d\00 \00n\00o\00t\00 \00e\00q\00u\00a\00l\00 \00t\00h\00e\00 \00s\00a\00m\00e\00 \00v\00a\00l\00u\00e\00")
+ (data (i32.const 2112) "L\00\00\00\01\00\00\00\01\00\00\00L\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00v\00a\00l\00u\00e\00A\00r\00r\00a\00y\00 \00i\00s\00 \003\00,\00 \00n\00o\00t\00 \001\000\00.\00")
+ (data (i32.const 2208) "R\00\00\00\01\00\00\00\01\00\00\00R\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00v\00a\00l\00u\00e\00A\00r\00r\00a\00y\00 \00i\00s\00 \003\00,\00 \00a\00n\00d\00 \00n\00o\00t\00 \001\000\00")
+ (data (i32.const 2320) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00t\00o\00H\00a\00v\00e\00L\00e\00n\00g\00t\00h\00 \00c\00u\00s\00t\00o\00m\00 \00c\00l\00a\00s\00s\00e\00s\00")
+ (data (i32.const 2400) "R\00\00\00\01\00\00\00\01\00\00\00R\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00u\00s\00t\00o\00m\00E\00x\00a\00m\00p\00l\00e\00 \00i\00s\00 \003\00,\00 \00n\00o\00t\00 \001\000\00.\00")
+ (data (i32.const 2512) "X\00\00\00\01\00\00\00\01\00\00\00X\00\00\00T\00h\00e\00 \00l\00e\00n\00g\00t\00h\00 \00o\00f\00 \00c\00u\00s\00t\00o\00m\00E\00x\00a\00m\00p\00l\00e\00 \00i\00s\00 \003\00,\00 \00a\00n\00d\00 \00n\00o\00t\00 \001\000\00")
+ (data (i32.const 2624) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00A\00r\00r\00a\00y\00B\00u\00f\00f\00e\00r\00")
+ (data (i32.const 2672) "D\00\00\00\01\00\00\00\01\00\00\00D\00\00\00s\00h\00o\00u\00l\00d\00 \00c\00o\00m\00p\00a\00r\00e\00 \00A\00r\00r\00a\00y\00B\00u\00f\00f\00e\00r\00 \00l\00e\00n\00g\00t\00h\00s\00")
+ (data (i32.const 2768) "n\00\00\00\01\00\00\00\01\00\00\00n\00\00\00A\00n\00 \00a\00r\00r\00a\00y\00 \00b\00u\00f\00f\00e\00r\00 \00w\00i\00t\00h\00 \00l\00e\00n\00g\00t\00h\00 \001\000\000\00 \00s\00h\00o\00u\00l\00d\00 \00h\00a\00v\00e\00 \00l\00e\00n\00g\00t\00h\00 \001\000\000\00.\00")
+ (data (i32.const 2896) " \00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00a\00\00\00\02\00\00\00 \00\00\00\00\00\00\000\t\02\00\00\00\00\00a\00\00\00\02\00\00\00 \00\00\00\00\00\00\00a\08\00\00\02\00\00\00 \00\00\00\00\00\00\00\a1\00\00\00\02\00\00\00 \00\00\00\00\00\00\00\a1\08\00\00\02\00\00\00 \00\00\00\00\00\00\00!\01\00\00\02\00\00\00 \00\00\00\00\00\00\00!\t\00\00\02\00\00\00 \00\00\00\00\00\00\00!\02\00\00\02\00\00\00 \00\00\00\00\00\00\00!\n\00\00\02\00\00\00 \00\00\00\00\00\00\00!\19\00\00\02\00\00\00 \00\00\00\00\00\00\00!\1a\00\00\02\00\00\00 \00\00\00\00\00\00\00\"\t\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\"\01\00\00\00\00\00\00")
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
  (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "__aspect" "createReflectedValue" (func $assembly/internal/Reflect/createReflectedValue (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
  (import "__aspect" "createReflectedNumber" (func $assembly/internal/Reflect/createReflectedNumber (param i32 i32 i32 i32 f64) (result i32)))
- (import "__aspect" "pushReflectedObjectValue" (func $assembly/internal/Reflect/__aspectPushReflectedObjectValue (param i32 i32)))
  (import "__aspect" "attachStackTraceToReflectedValue" (func $assembly/internal/Reflect/attachStackTraceToReflectedValue (param i32)))
  (import "__aspect" "reportActualReflectedValue" (func $assembly/internal/Actual/reportActualReflectedValue (param i32)))
  (import "__aspect" "reportExpectedReflectedValue" (func $assembly/internal/Expected/reportExpectedReflectedValue (param i32 i32)))
@@ -93,8 +66,6 @@
  (import "__aspect" "reportTestTypeNode" (func $assembly/internal/Test/it (param i32 i32)))
  (import "__aspect" "reportNegatedTestNode" (func $assembly/internal/Test/throws (param i32 i32 i32)))
  (import "__aspect" "reportGroupTypeNode" (func $assembly/internal/Test/describe (param i32 i32)))
- (import "__aspect" "createReflectedLong" (func $assembly/internal/Reflect/createReflectedLong (param i32 i32 i32 i32 i32 i32) (result i32)))
- (import "__aspect" "pushReflectedObjectKey" (func $assembly/internal/Reflect/__aspectPushReflectedObjectKey (param i32 i32)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (table $0 69 funcref)
@@ -108,15 +79,15 @@
  (global $assembly/internal/Reflect/Reflect.SUCCESSFUL_MATCH i32 (i32.const 1))
  (global $assembly/internal/Reflect/Reflect.DEFER_MATCH i32 (i32.const 2))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $assembly/__tests__/toHaveLength.spec/valueArray (mut i32) (i32.const 2272))
+ (global $assembly/__tests__/toHaveLength.spec/valueArray (mut i32) (i32.const 1872))
  (global $assembly/__tests__/toHaveLength.spec/customExample (mut i32) (i32.const 0))
- (global $assembly/internal/RTrace/RTrace.enabled (mut i32) (i32.const 1))
  (global $assembly/__tests__/setup/Test.include/meaningOfLife i32 (i32.const 42))
  (global $assembly/internal/noOp/noOp i32 (i32.const 68))
  (global $assembly/internal/log/ignoreLogs (mut i32) (i32.const 0))
+ (global $assembly/internal/RTrace/RTrace.enabled (mut i32) (i32.const 1))
  (global $~started (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 3456))
- (global $~lib/heap/__heap_base i32 (i32.const 3724))
+ (global $~lib/rt/__rtti_base i32 (i32.const 2896))
+ (global $~lib/heap/__heap_base i32 (i32.const 3156))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "table" (table $0))
@@ -3395,173 +3366,37 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
-  (local $1 i32)
-  i32.const -2128831035
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 8
-  i32.shr_u
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 16
-  i32.shr_u
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 24
-  i32.shr_u
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
- )
- (func $~lib/map/Map<usize,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $assembly/internal/Reflect/Reflect.toReflectedValue<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  local.get $0
-  i32.load
-  local.get $2
-  local.get $0
-  i32.load offset=4
-  i32.and
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 0
+  drop
+  i32.const 2
+  i32.const 3
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 0
+  end
+  drop
+  i32.const 1
   i32.const 4
-  i32.mul
-  i32.add
-  i32.load
-  local.set $3
-  loop $while-continue|0
-   local.get $3
-   local.set $4
-   local.get $4
-   if
-    local.get $3
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if (result i32)
-     local.get $3
-     i32.load
-     local.get $1
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     local.get $3
-     return
-    end
-    local.get $3
-    i32.load offset=8
-    i32.const 1
-    i32.const -1
-    i32.xor
-    i32.and
-    local.set $3
-    br $while-continue|0
-   end
-  end
-  i32.const 0
- )
- (func $~lib/map/Map<usize,i32>#has (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+  i32.const 7
+  i32.const 560
   local.get $0
-  local.get $1
-  block $~lib/util/hash/HASH<usize>|inlined.0 (result i32)
-   local.get $1
-   local.set $2
-   i32.const 0
-   drop
-   i32.const 0
-   drop
-   i32.const 0
-   drop
-   i32.const 4
-   i32.const 1
-   i32.eq
-   drop
-   i32.const 4
-   i32.const 2
-   i32.eq
-   drop
-   i32.const 4
-   i32.const 4
-   i32.eq
-   drop
-   local.get $2
-   call $~lib/util/hash/hash32
-   br $~lib/util/hash/HASH<usize>|inlined.0
-  end
-  call $~lib/map/Map<usize,i32>#find
-  i32.const 0
-  i32.ne
- )
- (func $~lib/map/Map<usize,i32>#get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $0
-  local.get $1
-  block $~lib/util/hash/HASH<usize>|inlined.1 (result i32)
-   local.get $1
-   local.set $2
-   i32.const 0
-   drop
-   i32.const 0
-   drop
-   i32.const 0
-   drop
-   i32.const 4
-   i32.const 1
-   i32.eq
-   drop
-   i32.const 4
-   i32.const 2
-   i32.eq
-   drop
-   i32.const 4
-   i32.const 4
-   i32.eq
-   drop
-   local.get $2
-   call $~lib/util/hash/hash32
-   br $~lib/util/hash/HASH<usize>|inlined.1
-  end
-  call $~lib/map/Map<usize,i32>#find
+  f64.convert_i32_s
+  call $assembly/internal/Reflect/createReflectedNumber
+  local.set $2
+  local.get $2
   local.set $3
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $3
-  i32.eqz
-  if
-   i32.const 560
-   i32.const 624
-   i32.const 111
-   i32.const 17
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $3
-  i32.load offset=4
+  return
  )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3591,475 +3426,6 @@
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
- )
- (func $~lib/map/Map<usize,i32>#rehash (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  local.get $1
-  i32.const 1
-  i32.add
-  local.set $2
-  i32.const 0
-  local.get $2
-  i32.const 4
-  i32.mul
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
-  local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
-  local.set $4
-  i32.const 0
-  local.get $4
-  i32.const 12
-  i32.mul
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $0
-  i32.load offset=8
-  local.set $6
-  local.get $6
-  local.get $0
-  i32.load offset=16
-  i32.const 12
-  i32.mul
-  i32.add
-  local.set $7
-  local.get $5
-  local.set $8
-  loop $while-continue|0
-   local.get $6
-   local.get $7
-   i32.ne
-   local.set $9
-   local.get $9
-   if
-    local.get $6
-    local.set $10
-    local.get $10
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $8
-     local.set $11
-     local.get $11
-     local.get $10
-     i32.load
-     i32.store
-     local.get $11
-     local.get $10
-     i32.load offset=4
-     i32.store offset=4
-     block $~lib/util/hash/HASH<usize>|inlined.3 (result i32)
-      local.get $10
-      i32.load
-      local.set $12
-      i32.const 0
-      drop
-      i32.const 0
-      drop
-      i32.const 0
-      drop
-      i32.const 4
-      i32.const 1
-      i32.eq
-      drop
-      i32.const 4
-      i32.const 2
-      i32.eq
-      drop
-      i32.const 4
-      i32.const 4
-      i32.eq
-      drop
-      local.get $12
-      call $~lib/util/hash/hash32
-      br $~lib/util/hash/HASH<usize>|inlined.3
-     end
-     local.get $1
-     i32.and
-     local.set $12
-     local.get $3
-     local.get $12
-     i32.const 4
-     i32.mul
-     i32.add
-     local.set $13
-     local.get $11
-     local.get $13
-     i32.load
-     i32.store offset=8
-     local.get $13
-     local.get $8
-     i32.store
-     local.get $8
-     i32.const 12
-     i32.add
-     local.set $8
-    end
-    local.get $6
-    i32.const 12
-    i32.add
-    local.set $6
-    br $while-continue|0
-   end
-  end
-  local.get $0
-  local.tee $11
-  local.get $3
-  local.tee $12
-  local.get $11
-  i32.load
-  local.tee $9
-  i32.ne
-  if
-   local.get $12
-   call $~lib/rt/pure/__retain
-   local.set $12
-   local.get $9
-   call $~lib/rt/pure/__release
-  end
-  local.get $12
-  i32.store
-  local.get $0
-  local.get $1
-  i32.store offset=4
-  local.get $0
-  local.tee $13
-  local.get $5
-  local.tee $9
-  local.get $13
-  i32.load offset=8
-  local.tee $11
-  i32.ne
-  if
-   local.get $9
-   call $~lib/rt/pure/__retain
-   local.set $9
-   local.get $11
-   call $~lib/rt/pure/__release
-  end
-  local.get $9
-  i32.store offset=8
-  local.get $0
-  local.get $4
-  i32.store offset=12
-  local.get $0
-  local.get $0
-  i32.load offset=20
-  i32.store offset=16
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
- )
- (func $~lib/map/Map<usize,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  block $~lib/util/hash/HASH<usize>|inlined.2 (result i32)
-   local.get $1
-   local.set $3
-   i32.const 0
-   drop
-   i32.const 0
-   drop
-   i32.const 0
-   drop
-   i32.const 4
-   i32.const 1
-   i32.eq
-   drop
-   i32.const 4
-   i32.const 2
-   i32.eq
-   drop
-   i32.const 4
-   i32.const 4
-   i32.eq
-   drop
-   local.get $3
-   call $~lib/util/hash/hash32
-   br $~lib/util/hash/HASH<usize>|inlined.2
-  end
-  local.set $4
-  local.get $0
-  local.get $1
-  local.get $4
-  call $~lib/map/Map<usize,i32>#find
-  local.set $5
-  local.get $5
-  if
-   i32.const 0
-   drop
-   local.get $5
-   local.get $2
-   i32.store offset=4
-  else
-   local.get $0
-   i32.load offset=16
-   local.get $0
-   i32.load offset=12
-   i32.eq
-   if
-    local.get $0
-    local.get $0
-    i32.load offset=20
-    local.get $0
-    i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.const 4
-    i32.div_s
-    i32.lt_s
-    if (result i32)
-     local.get $0
-     i32.load offset=4
-    else
-     local.get $0
-     i32.load offset=4
-     i32.const 1
-     i32.shl
-     i32.const 1
-     i32.or
-    end
-    call $~lib/map/Map<usize,i32>#rehash
-   end
-   local.get $0
-   i32.load offset=8
-   call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $3
-   local.get $0
-   local.get $0
-   i32.load offset=16
-   local.tee $6
-   i32.const 1
-   i32.add
-   i32.store offset=16
-   local.get $6
-   i32.const 12
-   i32.mul
-   i32.add
-   local.set $5
-   local.get $5
-   local.get $1
-   i32.store
-   local.get $5
-   local.get $2
-   i32.store offset=4
-   local.get $0
-   local.get $0
-   i32.load offset=20
-   i32.const 1
-   i32.add
-   i32.store offset=20
-   local.get $0
-   i32.load
-   local.get $4
-   local.get $0
-   i32.load offset=4
-   i32.and
-   i32.const 4
-   i32.mul
-   i32.add
-   local.set $6
-   local.get $5
-   local.get $6
-   i32.load
-   i32.store offset=8
-   local.get $6
-   local.get $5
-   i32.store
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $0
-  call $~lib/rt/pure/__retain
- )
- (func $~lib/typedarray/Uint8Array#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.add
-  i32.load8_u
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<u8> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 0
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 0
-  i32.const 1
-  i32.const 7
-  i32.const 672
-  local.get $0
-  f64.convert_i32_u
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 3
-   i32.const 192
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Uint8Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 3
-  i32.const 192
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Uint8Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<u8>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
  )
  (func $~lib/map/Map<usize,i32>#clear (param $0 i32)
   (local $1 i32)
@@ -4133,86 +3499,6 @@
   call $~lib/map/Map<usize,i32>#clear
   local.get $0
  )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Reflect/Reflect.attachStackTrace (param $0 i32)
-  local.get $0
-  call $assembly/internal/Reflect/attachStackTraceToReflectedValue
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint8Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<i32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 2
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 1
-  i32.const 4
-  i32.const 7
-  i32.const 704
-  local.get $0
-  f64.convert_i32_s
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
  (func $assembly/internal/Reflect/Reflect.toReflectedValue<i32>@varargs (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -4239,6 +3525,23 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
+ (func $assembly/internal/Reflect/Reflect.attachStackTrace (param $0 i32)
+  local.get $0
+  call $assembly/internal/Reflect/attachStackTraceToReflectedValue
+ )
+ (func $assembly/internal/Actual/Actual.report<i32> (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.const 1
+  global.set $~argumentsLength
+  i32.const 0
+  call $assembly/internal/Reflect/Reflect.toReflectedValue<i32>@varargs
+  local.set $1
+  local.get $1
+  call $assembly/internal/Reflect/Reflect.attachStackTrace
+  local.get $1
+  call $assembly/internal/Actual/reportActualReflectedValue
+ )
  (func $assembly/internal/Expected/Expected.report<i32> (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -4261,7 +3564,7 @@
   i32.eqz
   if
    local.get $1
-   i32.const 736
+   i32.const 592
    i32.const 2
    i32.const 19
    call $~lib/builtins/abort
@@ -4301,10 +3604,10 @@
   local.get $3
   call $~lib/typedarray/Uint8Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint8Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -4378,7 +3681,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint8Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint8Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -4407,16 +3710,16 @@
   i32.const 368
   i32.const 1
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 2
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 3
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 4
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint8Array> (param $0 i32)
@@ -4560,187 +3863,6 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.add
-  i32.load8_u
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8ClampedArray> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 6
-   i32.const 1488
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Uint8ClampedArray#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 6
-  i32.const 1488
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Uint8ClampedArray#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<u8>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8ClampedArray>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8ClampedArray>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint8ClampedArray> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint8ClampedArray>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint8ClampedArray>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4766,10 +3888,10 @@
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint8ClampedArray>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -4843,7 +3965,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint8ClampedArray>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint8ClampedArray>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -4872,16 +3994,16 @@
   i32.const 368
   i32.const 6
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 7
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 8
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 9
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint8ClampedArray> (param $0 i32)
@@ -5013,219 +4135,6 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Int8Array#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.add
-  i32.load8_s
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<i8> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 0
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 1
-  i32.const 1
-  i32.const 7
-  i32.const 1600
-  local.get $0
-  f64.convert_i32_s
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int8Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 8
-   i32.const 1552
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Int8Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 8
-  i32.const 1552
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Int8Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<i8>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int8Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int8Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Int8Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int8Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Int8Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5251,10 +4160,10 @@
   local.get $3
   call $~lib/typedarray/Int8Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Int8Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -5328,7 +4237,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int8Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int8Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -5357,16 +4266,16 @@
   i32.const 368
   i32.const 11
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 12
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 13
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 14
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int8Array> (param $0 i32)
@@ -5502,221 +4411,6 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/typedarray/Uint16Array#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  i32.load16_u
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<u16> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 1
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 0
-  i32.const 2
-  i32.const 7
-  i32.const 1680
-  local.get $0
-  f64.convert_i32_u
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint16Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 10
-   i32.const 1632
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Uint16Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 10
-  i32.const 1632
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Uint16Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<u16>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint16Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint16Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint16Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint16Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint16Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5742,10 +4436,10 @@
   local.get $3
   call $~lib/typedarray/Uint16Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint16Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -5819,7 +4513,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint16Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint16Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -5848,16 +4542,16 @@
   i32.const 368
   i32.const 16
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 17
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 18
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 19
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint16Array> (param $0 i32)
@@ -5993,221 +4687,6 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/typedarray/Int16Array#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  i32.load16_s
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<i16> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 1
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 1
-  i32.const 2
-  i32.const 7
-  i32.const 1760
-  local.get $0
-  f64.convert_i32_s
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 12
-   i32.const 1712
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Int16Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 12
-  i32.const 1712
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Int16Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<i16>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int16Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int16Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Int16Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int16Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Int16Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6233,10 +4712,10 @@
   local.get $3
   call $~lib/typedarray/Int16Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Int16Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -6310,7 +4789,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int16Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int16Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -6339,16 +4818,16 @@
   i32.const 368
   i32.const 21
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 22
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 23
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 24
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int16Array> (param $0 i32)
@@ -6484,221 +4963,6 @@
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Uint32Array#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<u32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 2
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 0
-  i32.const 4
-  i32.const 7
-  i32.const 1840
-  local.get $0
-  f64.convert_i32_u
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint32Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 14
-   i32.const 1792
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Uint32Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 14
-  i32.const 1792
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Uint32Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<u32>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint32Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint32Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint32Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint32Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint32Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6724,10 +4988,10 @@
   local.get $3
   call $~lib/typedarray/Uint32Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint32Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -6801,7 +5065,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint32Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint32Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -6830,16 +5094,16 @@
   i32.const 368
   i32.const 26
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 27
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 28
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 29
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint32Array> (param $0 i32)
@@ -6975,189 +5239,6 @@
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Int32Array#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int32Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 16
-   i32.const 1872
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Int32Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 16
-  i32.const 1872
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Int32Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<i32>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int32Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int32Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Int32Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int32Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Int32Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7183,10 +5264,10 @@
   local.get $3
   call $~lib/typedarray/Int32Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Int32Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -7260,7 +5341,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int32Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int32Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -7289,16 +5370,16 @@
   i32.const 368
   i32.const 31
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 32
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 33
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 34
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int32Array> (param $0 i32)
@@ -7434,227 +5515,6 @@
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Uint64Array#__uget (param $0 i32) (param $1 i32) (result i64)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  i64.load
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<u64> (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 3
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 0
-  i32.const 8
-  i32.const 7
-  i32.const 1968
-  local.get $0
-  i64.const 4294967295
-  i64.and
-  i32.wrap_i64
-  local.get $0
-  i64.const 32
-  i64.shr_u
-  i32.wrap_i64
-  call $assembly/internal/Reflect/createReflectedLong
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint64Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i64)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 18
-   i32.const 1920
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Uint64Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 18
-  i32.const 1920
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Uint64Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<u64>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint64Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint64Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint64Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Uint64Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint64Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7680,10 +5540,10 @@
   local.get $3
   call $~lib/typedarray/Uint64Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Uint64Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -7757,7 +5617,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint64Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Uint64Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -7786,16 +5646,16 @@
   i32.const 368
   i32.const 36
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 37
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 38
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 39
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint64Array> (param $0 i32)
@@ -7931,227 +5791,6 @@
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Int64Array#__uget (param $0 i32) (param $1 i32) (result i64)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  i64.load
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<i64> (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 3
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 1
-  i32.const 8
-  i32.const 7
-  i32.const 2048
-  local.get $0
-  i64.const 4294967295
-  i64.and
-  i32.wrap_i64
-  local.get $0
-  i64.const 32
-  i64.shr_u
-  i32.wrap_i64
-  call $assembly/internal/Reflect/createReflectedLong
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i64)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 20
-   i32.const 2000
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Int64Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 20
-  i32.const 2000
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Int64Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<i64>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int64Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int64Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Int64Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Int64Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Int64Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8177,10 +5816,10 @@
   local.get $3
   call $~lib/typedarray/Int64Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Int64Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -8254,7 +5893,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int64Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Int64Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -8283,16 +5922,16 @@
   i32.const 368
   i32.const 41
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 42
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 43
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 44
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int64Array> (param $0 i32)
@@ -8428,221 +6067,6 @@
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Float32Array#__uget (param $0 i32) (param $1 i32) (result f32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  f32.load
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<f32> (param $0 f32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 2
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 0
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 1
-  i32.const 4
-  i32.const 8
-  i32.const 2128
-  local.get $0
-  f64.promote_f32
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float32Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 f32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 22
-   i32.const 2080
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Float32Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 22
-  i32.const 2080
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Float32Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<f32>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float32Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float32Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Float32Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float32Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Float32Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8668,10 +6092,10 @@
   local.get $3
   call $~lib/typedarray/Float32Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Float32Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -8745,7 +6169,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Float32Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Float32Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -8774,16 +6198,16 @@
   i32.const 368
   i32.const 46
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 47
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 48
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 49
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Float32Array> (param $0 i32)
@@ -8919,220 +6343,6 @@
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Float64Array#__uget (param $0 i32) (param $1 i32) (result f64)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  f64.load
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<f64> (param $0 f64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 0
-  drop
-  i32.const 3
-  i32.const 3
-  i32.eq
-  if (result i32)
-   i32.const 0
-  else
-   i32.const 0
-  end
-  drop
-  i32.const 1
-  i32.const 8
-  i32.const 8
-  i32.const 2208
-  local.get $0
-  call $assembly/internal/Reflect/createReflectedNumber
-  local.set $2
-  local.get $2
-  local.set $3
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float64Array> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 f64)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 24
-   i32.const 2160
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/typedarray/Float64Array#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 11
-  i32.const 24
-  i32.const 2160
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/typedarray/Float64Array#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<f64>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float64Array>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float64Array>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/typedarray/Float64Array> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/typedarray/Float64Array>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/typedarray/Float64Array>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9158,10 +6368,10 @@
   local.get $3
   call $~lib/typedarray/Float64Array#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/typedarray/Float64Array>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -9235,7 +6445,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Float64Array>#get:not
   local.tee $2
   i32.const 10
-  i32.const 1184
+  i32.const 1040
   call $assembly/internal/Expectation/Expectation<~lib/typedarray/Float64Array>#toHaveLength
   local.get $1
   call $~lib/rt/pure/__release
@@ -9264,16 +6474,16 @@
   i32.const 368
   i32.const 51
   call $assembly/internal/Test/it
-  i32.const 816
+  i32.const 672
   i32.const 52
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 53
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 54
-  i32.const 1392
+  i32.const 1248
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Float64Array> (param $0 i32)
@@ -9352,193 +6562,6 @@
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 26
-   i32.const 2368
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/array/Array<i32>#get:length
-  local.set $2
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $2
-  i32.const 10
-  i32.const 26
-  i32.const 2368
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $3
-  local.get $1
-  local.get $0
-  local.get $3
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $2
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $0
-    local.get $4
-    call $~lib/array/Array<i32>#__uget
-    local.set $6
-    local.get $6
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<i32>
-    local.set $7
-    local.get $3
-    local.get $7
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $3
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/array/Array<i32>>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/array/Array<i32>>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/array/Array<i32>> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/array/Array<i32>>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/array/Array<i32>>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9564,10 +6587,10 @@
   local.get $3
   call $~lib/array/Array<i32>#get:length
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/array/Array<i32>>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -9628,7 +6651,7 @@
   call $assembly/internal/Expectation/Expectation<~lib/array/Array<i32>>#get:not
   local.tee $1
   i32.const 10
-  i32.const 2576
+  i32.const 2128
   call $assembly/internal/Expectation/Expectation<~lib/array/Array<i32>>#toHaveLength
   local.get $0
   call $~lib/rt/pure/__release
@@ -9650,16 +6673,16 @@
   i32.const 368
   i32.const 56
   call $assembly/internal/Test/it
-  i32.const 2416
+  i32.const 1968
   i32.const 57
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 58
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 59
-  i32.const 2672
+  i32.const 2224
   call $assembly/internal/Test/throws
  )
  (func $assembly/__tests__/toHaveLength.spec/Example#constructor (param $0 i32) (result i32)
@@ -9733,400 +6756,6 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $assembly/internal/RTrace/RTrace.sizeOf (param $0 i32) (result i32)
-  local.get $0
-  i32.const 16
-  i32.sub
-  i32.load offset=12
- )
- (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  local.get $0
-  local.get $1
-  call $~lib/rt/tlsf/__alloc
-  local.set $3
-  local.get $2
-  if
-   local.get $3
-   local.get $2
-   local.get $0
-   call $~lib/memory/memory.copy
-  end
-  local.get $3
- )
- (func $~lib/staticarray/StaticArray<i64>#get:length (param $0 i32) (result i32)
-  local.get $0
-  i32.const 16
-  i32.sub
-  i32.load offset=12
-  i32.const 3
-  i32.shr_u
- )
- (func $~lib/staticarray/StaticArray<i64>#indexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $0
-  call $~lib/staticarray/StaticArray<i64>#get:length
-  local.set $3
-  local.get $3
-  i32.const 0
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $2
-   local.get $3
-   i32.ge_s
-  end
-  if
-   i32.const -1
-   return
-  end
-  local.get $2
-  i32.const 0
-  i32.lt_s
-  if
-   local.get $3
-   local.get $2
-   i32.add
-   local.tee $4
-   i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   local.set $2
-  end
-  loop $while-continue|0
-   local.get $2
-   local.get $3
-   i32.lt_s
-   local.set $4
-   local.get $4
-   if
-    local.get $0
-    local.get $2
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $1
-    i64.eq
-    if
-     local.get $2
-     return
-    end
-    local.get $2
-    i32.const 1
-    i32.add
-    local.set $2
-    br $while-continue|0
-   end
-  end
-  i32.const -1
- )
- (func $~lib/staticarray/StaticArray<i64>#includes (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
-  i32.const 0
-  drop
-  local.get $0
-  local.get $1
-  local.get $2
-  call $~lib/staticarray/StaticArray<i64>#indexOf
-  i32.const 0
-  i32.ge_s
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/string/String> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 1
-   i32.const 2944
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  i32.const 0
-  local.get $0
-  call $~lib/string/String#get:length
-  i32.const 2
-  i32.const 1
-  i32.const 2944
-  local.get $0
-  i32.const 0
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $2
-  local.get $1
-  local.get $0
-  local.get $2
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  local.get $2
-  local.set $3
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $3
-  return
- )
- (func $assembly/__tests__/toHaveLength.spec/Example#__aspectAddReflectedValueKeyValuePairs (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
-  local.get $2
-  call $~lib/rt/pure/__retain
-  local.set $2
-  local.get $3
-  call $~lib/rt/pure/__retain
-  local.set $3
-  i32.const 0
-  drop
-  local.get $3
-  i64.const 4730569431367811072
-  i32.const 0
-  call $~lib/staticarray/StaticArray<i64>#includes
-  i32.eqz
-  if
-   local.get $1
-   i32.const 2912
-   local.get $2
-   call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/string/String>
-   call $assembly/internal/Reflect/__aspectPushReflectedObjectKey
-   local.get $1
-   local.get $0
-   i32.load
-   local.get $2
-   call $assembly/internal/Reflect/Reflect.toReflectedValue<i32>
-   call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-  end
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<assembly/__tests__/toHaveLength.spec/Example> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 28
-   i32.const 2864
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  drop
-  i32.const 0
-  i32.const 1
-  i32.const 0
-  i32.const 4
-  local.get $0
-  i32.const 0
-  local.get $0
-  call $assembly/internal/RTrace/RTrace.sizeOf
-  i32.const 1
-  i32.const 28
-  i32.const 2864
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $2
-  local.get $1
-  local.get $0
-  local.get $2
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $2
-  local.get $1
-  i32.const 0
-  i32.const 30
-  i32.const 2896
-  call $~lib/rt/__allocBuffer
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  call $assembly/__tests__/toHaveLength.spec/Example#__aspectAddReflectedValueKeyValuePairs
-  local.get $2
-  local.set $4
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<assembly/__tests__/toHaveLength.spec/Example>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<assembly/__tests__/toHaveLength.spec/Example>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<assembly/__tests__/toHaveLength.spec/Example> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<assembly/__tests__/toHaveLength.spec/Example>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<assembly/__tests__/toHaveLength.spec/Example>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10152,10 +6781,10 @@
   local.get $3
   i32.load
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<assembly/__tests__/toHaveLength.spec/Example>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -10216,7 +6845,7 @@
   call $assembly/internal/Expectation/Expectation<assembly/__tests__/toHaveLength.spec/Example>#get:not
   local.tee $1
   i32.const 10
-  i32.const 2976
+  i32.const 2416
   call $assembly/internal/Expectation/Expectation<assembly/__tests__/toHaveLength.spec/Example>#toHaveLength
   local.get $0
   call $~lib/rt/pure/__release
@@ -10238,16 +6867,16 @@
   i32.const 368
   i32.const 61
   call $assembly/internal/Test/it
-  i32.const 2416
+  i32.const 1968
   i32.const 62
-  i32.const 944
+  i32.const 800
   call $assembly/internal/Test/throws
-  i32.const 1072
+  i32.const 928
   i32.const 63
   call $assembly/internal/Test/it
-  i32.const 1280
+  i32.const 1136
   i32.const 64
-  i32.const 3088
+  i32.const 2528
   call $assembly/internal/Test/throws
  )
  (func $assembly/internal/Expectation/Expectation<~lib/arraybuffer/ArrayBuffer>#constructor (param $0 i32) (param $1 i32) (result i32)
@@ -10258,7 +6887,7 @@
   i32.eqz
   if
    i32.const 8
-   i32.const 31
+   i32.const 30
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -10312,169 +6941,6 @@
   i32.sub
   i32.load offset=12
  )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/arraybuffer/ArrayBuffer> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 1
-  drop
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 1
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 0
-   i32.const 4
-   i32.const 1
-   i32.const 0
-   i32.const 3200
-   i32.const 0
-   i32.const 0
-   i32.const 1
-   call $assembly/internal/Reflect/createReflectedValue
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $1
-  local.get $0
-  call $~lib/map/Map<usize,i32>#has
-  if
-   local.get $1
-   local.get $0
-   call $~lib/map/Map<usize,i32>#get
-   local.set $2
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $2
-   return
-  end
-  i32.const 0
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.const 0
-  i32.const 0
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.get $0
-  i32.const 0
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.const 3
-  i32.const 0
-  i32.const 3200
-  i32.const 0
-  i32.const 1
-  i32.const 1
-  call $assembly/internal/Reflect/createReflectedValue
-  local.set $2
-  local.get $1
-  local.get $0
-  local.get $2
-  call $~lib/map/Map<usize,i32>#set
-  call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $3
-  i32.const 0
-  local.set $4
-  loop $for-loop|0
-   local.get $4
-   local.get $3
-   i32.lt_s
-   local.set $5
-   local.get $5
-   if
-    local.get $2
-    local.get $0
-    local.get $4
-    i32.add
-    i32.load8_u
-    local.get $1
-    call $assembly/internal/Reflect/Reflect.toReflectedValue<u8>
-    call $assembly/internal/Reflect/__aspectPushReflectedObjectValue
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $2
-  local.set $4
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $4
-  return
- )
- (func $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/arraybuffer/ArrayBuffer>@varargs (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  block $1of1
-   block $0of1
-    block $outOfRange
-     global.get $~argumentsLength
-     i32.const 1
-     i32.sub
-     br_table $0of1 $1of1 $outOfRange
-    end
-    unreachable
-   end
-   i32.const 0
-   call $~lib/map/Map<usize,i32>#constructor
-   local.tee $2
-   local.set $1
-  end
-  local.get $0
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/arraybuffer/ArrayBuffer>
-  local.set $3
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $assembly/internal/Actual/Actual.report<~lib/arraybuffer/ArrayBuffer> (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  call $assembly/internal/Reflect/Reflect.toReflectedValue<~lib/arraybuffer/ArrayBuffer>@varargs
-  local.set $1
-  local.get $1
-  call $assembly/internal/Reflect/Reflect.attachStackTrace
-  local.get $1
-  call $assembly/internal/Actual/reportActualReflectedValue
-  local.get $0
-  call $~lib/rt/pure/__release
- )
  (func $assembly/internal/Expectation/Expectation<~lib/arraybuffer/ArrayBuffer>#toHaveLength (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10497,10 +6963,10 @@
   local.get $3
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   local.set $5
-  local.get $3
-  call $assembly/internal/Actual/Actual.report<~lib/arraybuffer/ArrayBuffer>
   local.get $5
-  i32.const 0
+  call $assembly/internal/Actual/Actual.report<i32>
+  local.get $1
+  local.get $4
   call $assembly/internal/Expected/Expected.report<i32>
   local.get $5
   local.get $1
@@ -10528,7 +6994,7 @@
   call $assembly/internal/Expectation/expect<~lib/arraybuffer/ArrayBuffer>
   local.tee $1
   i32.const 100
-  i32.const 3344
+  i32.const 2784
   call $assembly/internal/Expectation/Expectation<~lib/arraybuffer/ArrayBuffer>#toHaveLength
   local.get $0
   call $~lib/rt/pure/__release
@@ -10536,7 +7002,7 @@
   call $~lib/rt/pure/__release
  )
  (func $start:assembly/__tests__/toHaveLength.spec~anonymous|2
-  i32.const 3248
+  i32.const 2688
   i32.const 66
   call $assembly/internal/Test/it
  )
@@ -10545,36 +7011,36 @@
   (local $1 i32)
   i32.const 192
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint8Array>
-  i32.const 1488
+  i32.const 1344
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint8ClampedArray>
-  i32.const 1552
+  i32.const 1408
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int8Array>
-  i32.const 1632
+  i32.const 1456
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint16Array>
-  i32.const 1712
+  i32.const 1504
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int16Array>
-  i32.const 1792
+  i32.const 1552
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint32Array>
-  i32.const 1872
+  i32.const 1600
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int32Array>
-  i32.const 1920
+  i32.const 1648
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Uint64Array>
-  i32.const 2000
+  i32.const 1696
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Int64Array>
-  i32.const 2080
+  i32.const 1744
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Float32Array>
-  i32.const 2160
+  i32.const 1792
   call $assembly/__tests__/toHaveLength.spec/runTypedArrayTest<~lib/typedarray/Float64Array>
-  i32.const 2304
+  i32.const 1904
   i32.const 60
   call $assembly/internal/Test/describe
   i32.const 0
   call $assembly/__tests__/toHaveLength.spec/Example#constructor
   global.set $assembly/__tests__/toHaveLength.spec/customExample
-  i32.const 2784
+  i32.const 2336
   i32.const 65
   call $assembly/internal/Test/describe
-  i32.const 3200
+  i32.const 2640
   i32.const 67
   call $assembly/internal/Test/describe
  )
@@ -10598,7 +7064,7 @@
   global.set $assembly/internal/RTrace/RTrace.enabled
  )
  (func $assembly/internal/RTrace/__getUsizeArrayId (result i32)
-  i32.const 32
+  i32.const 31
  )
  (func $~start
   global.get $~started
@@ -10778,10 +7244,6 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/staticarray/StaticArray<i64>#__visit_impl (param $0 i32) (param $1 i32)
-  i32.const 0
-  drop
- )
  (func $~lib/array/Array<usize>#__visit_impl (param $0 i32) (param $1 i32)
   i32.const 0
   drop
@@ -10793,33 +7255,22 @@
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
-   block $switch$1$case$34
-    block $switch$1$case$32
-     block $switch$1$case$28
-      block $switch$1$case$7
-       block $switch$1$case$6
-        block $switch$1$case$4
-         block $switch$1$case$2
-          local.get $0
-          i32.const 8
-          i32.sub
-          i32.load
-          br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$4 $switch$1$case$6 $switch$1$case$7 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$28 $switch$1$case$6 $switch$1$case$2 $switch$1$case$6 $switch$1$case$32 $switch$1$case$6 $switch$1$case$34 $switch$1$default
-         end
-         return
-        end
-        local.get $0
-        i32.load
-        local.tee $2
-        if
-         local.get $2
-         local.get $1
-         call $~lib/rt/pure/__visit
+   block $switch$1$case$33
+    block $switch$1$case$28
+     block $switch$1$case$7
+      block $switch$1$case$6
+       block $switch$1$case$4
+        block $switch$1$case$2
+         local.get $0
+         i32.const 8
+         i32.sub
+         i32.load
+         br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$4 $switch$1$case$6 $switch$1$case$7 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$4 $switch$1$case$6 $switch$1$case$28 $switch$1$case$6 $switch$1$case$2 $switch$1$case$6 $switch$1$case$6 $switch$1$case$33 $switch$1$default
         end
         return
        end
        local.get $0
-       i32.load offset=4
+       i32.load
        local.tee $2
        if
         local.get $2
@@ -10829,18 +7280,23 @@
        return
       end
       local.get $0
-      local.get $1
-      call $~lib/map/Map<usize,i32>#__visit_impl
+      i32.load offset=4
+      local.tee $2
+      if
+       local.get $2
+       local.get $1
+       call $~lib/rt/pure/__visit
+      end
       return
      end
      local.get $0
      local.get $1
-     call $~lib/array/Array<i32>#__visit_impl
+     call $~lib/map/Map<usize,i32>#__visit_impl
      return
     end
     local.get $0
     local.get $1
-    call $~lib/staticarray/StaticArray<i64>#__visit_impl
+    call $~lib/array/Array<i32>#__visit_impl
     return
    end
    local.get $0

--- a/packages/assembly/assembly/internal/Expectation.ts
+++ b/packages/assembly/assembly/internal/Expectation.ts
@@ -430,7 +430,6 @@ export class Expectation<T> {
     let actual = this.actual;
     let negated = this._not;
     let length = <i32>0;
-
     if (actual instanceof ArrayBuffer) {
       length = actual.byteLength;
     } else {
@@ -440,11 +439,11 @@ export class Expectation<T> {
           "toHaveLength cannot be called on type T where T.length is not defined.",
         );
       // @ts-ignore: This results in a compile time check for a length property with a better error message
-      length = actual.length;
+      length = <i32>actual.length;
     }
 
-    Actual.report(actual);
-    Expected.report(length);
+    Actual.report(length);
+    Expected.report(expected, negated);
 
     let lengthsEqual = i32(length == expected);
     assert(lengthsEqual ^ negated, message);

--- a/packages/core/__tests__/__snapshots__/TestContext.pass-fail.spec.ts.snap
+++ b/packages/core/__tests__/__snapshots__/TestContext.pass-fail.spec.ts.snap
@@ -650,7 +650,7 @@ ReflectedValue {
   "negated": false,
   "nullable": false,
   "offset": 0,
-  "pointer": 7296,
+  "pointer": 7488,
   "signed": false,
   "size": 3,
   "stack": "Has Stack Trace",
@@ -742,7 +742,7 @@ ReflectedValue {
   "negated": false,
   "nullable": false,
   "offset": 0,
-  "pointer": 7392,
+  "pointer": 7584,
   "signed": false,
   "size": 3,
   "stack": "Has Stack Trace",
@@ -1902,7 +1902,7 @@ ReflectedValue {
   "negated": false,
   "nullable": false,
   "offset": 24,
-  "pointer": 7072,
+  "pointer": 7264,
   "signed": false,
   "size": 24,
   "stack": "Has Stack Trace",
@@ -2046,7 +2046,7 @@ ReflectedValue {
   "negated": false,
   "nullable": false,
   "offset": 24,
-  "pointer": 7152,
+  "pointer": 7344,
   "signed": false,
   "size": 24,
   "stack": "Has Stack Trace",
@@ -2280,7 +2280,7 @@ ReflectedValue {
   "negated": false,
   "nullable": false,
   "offset": 0,
-  "pointer": 7456,
+  "pointer": 7648,
   "signed": false,
   "size": 3,
   "stack": "Has Stack Trace",
@@ -2366,7 +2366,7 @@ ReflectedValue {
   "negated": false,
   "nullable": false,
   "offset": 0,
-  "pointer": 7536,
+  "pointer": 7728,
   "signed": false,
   "size": 3,
   "stack": "Has Stack Trace",
@@ -2593,5 +2593,101 @@ exports[`pass-fail output Node: !~pass-fail[0]: ran 1`] = `true`;
 exports[`pass-fail output Node: !~pass-fail[0]: reallocs 1`] = `0`;
 
 exports[`pass-fail output Node: !~pass-fail[0]: type 1`] = `1`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: actual 1`] = `
+ReflectedValue {
+  "isManaged": false,
+  "isNull": false,
+  "keys": null,
+  "negated": false,
+  "nullable": false,
+  "offset": 0,
+  "pointer": 0,
+  "signed": true,
+  "size": 4,
+  "stack": "Has Stack Trace",
+  "type": 7,
+  "typeId": 0,
+  "typeName": "i32",
+  "value": 3,
+  "values": null,
+}
+`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: actual-stringify 1`] = `"  number: 3"`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: afterAllPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: afterEachPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: allocations 1`] = `7`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: beforeAllPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: beforeEachPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: decrements 1`] = `8`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: expected 1`] = `
+ReflectedValue {
+  "isManaged": false,
+  "isNull": false,
+  "keys": null,
+  "negated": false,
+  "nullable": false,
+  "offset": 0,
+  "pointer": 0,
+  "signed": true,
+  "size": 4,
+  "stack": "Has Stack Trace",
+  "type": 7,
+  "typeId": 0,
+  "typeName": "i32",
+  "value": 5,
+  "values": null,
+}
+`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: expected-stringify 1`] = `"  number: 5"`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: frees 1`] = `6`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: increments 1`] = `9`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: message 1`] = `"the reason"`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: pass 1`] = `false`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: ran 1`] = `true`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: reallocs 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]!~fails[0]: type 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: afterAllPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: afterEachPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: allocations 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: beforeAllPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: beforeEachPointers 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: decrements 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: frees 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: increments 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: message 1`] = `null`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: pass 1`] = `false`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: ran 1`] = `true`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: reallocs 1`] = `0`;
+
+exports[`pass-fail output Node: !~toHaveLength[0]: type 1`] = `1`;
 
 exports[`pass-fail output Overall Statistics: pass 1`] = `false`;

--- a/packages/core/assembly/jest-pass-fail.ts
+++ b/packages/core/assembly/jest-pass-fail.ts
@@ -240,3 +240,11 @@ describe("nested fail in beforeAll", () => {
     });
   });
 });
+
+let a = [1, 2, 3];
+
+describe("toHaveLength", () => {
+  test("fails", () => {
+    expect(a).toHaveLength(5, "the reason");
+  });
+});


### PR DESCRIPTION
Nice to see all the snapshot tests are getting some value now!  I found this regression when helping lume/glas update to the latest compiler version.

I should be able to release 3.2.1 by the end of the week.