### PR TITLE
Increase verbose reporter expand depth

### DIFF
--- a/packages/core/src/reporter/VerboseReporter.ts
+++ b/packages/core/src/reporter/VerboseReporter.ts
@@ -16,7 +16,7 @@ export class VerboseReporter implements IReporter {
   public stderr: IWritable | null = null;
 
   /** A set of default stringify properties that can be overridden. */
-  protected stringifyProperties: Partial<StringifyReflectedValueProps> = {};
+  protected stringifyProperties: Partial<StringifyReflectedValueProps> = { maxExpandLevel: 10 };
 
   constructor(_options?: any) {}
 

--- a/packages/core/src/util/stringifyReflectedValue.ts
+++ b/packages/core/src/util/stringifyReflectedValue.ts
@@ -47,6 +47,8 @@ export function stringifyReflectedValue(
   /* istanbul ignore next */
   if (props.numberFormatter) context.numberFormatter = props.numberFormatter;
   /* istanbul ignore next */
+  if (props.maxExpandLevel) context.maxExpandLevel = props.maxExpandLevel;
+  /* istanbul ignore next */
   if (typeof props.indent === "number") context.indent = props.indent;
   /* istanbul ignore next */
   if (typeof props.tab === "number") context.tab = props.tab;


### PR DESCRIPTION
Issue: https://github.com/jtenner/as-pect/issues/282

When printing a deeply nested object in verbose mode, the input was getting cut off fairly quickly. I've increased the expand level for the verbose reporter from the default of 3 to 10. This allows verbose mode to be truly verbose.